### PR TITLE
fix parser for funccall with chained recv

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -212,15 +212,6 @@ func (lc *LiteralCallExpr) String() string {
 	out.WriteString(lc.Chain.String())
 	out.WriteString(lc.Func.String())
 
-	args := []string{}
-	for _, a := range lc.Args {
-		args = append(args, a.String())
-	}
-
-	args = append(args, sortedPairStrings(lc.Kwargs)...)
-
-	out.WriteString("(" + strings.Join(args, ", ") + ")")
-
 	return out.String()
 }
 


### PR DESCRIPTION
enable to use function call syntax sugar for other than ident and funcLiteral

example:

```
# syntax sugar for {}['bear].call(1, {a: 1})
# (equivalent to 1.bear({a: 1}))
>{}['bear](1, {a: 1})
{"a": 1}
```


