### PR TITLE
Feature/add obj iter

### DIFF
--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -2507,6 +2507,78 @@ func TestEvalObjValues(t *testing.T) {
 	}
 }
 
+func TestEvalObjItems(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected object.PanObject
+	}{
+		{
+			`{}.items`,
+			&object.PanArr{Elems: []object.PanObject{}},
+		},
+		{
+			`{a: "A", b: "B"}.items`,
+			&object.PanArr{Elems: []object.PanObject{
+				&object.PanArr{Elems: []object.PanObject{
+					object.NewPanStr("a"),
+					object.NewPanStr("A"),
+				}},
+				&object.PanArr{Elems: []object.PanObject{
+					object.NewPanStr("b"),
+					object.NewPanStr("B"),
+				}},
+			}},
+		},
+		// private keys are ignored
+		{
+			`{
+			   a: "A",
+			   _b: "_B",
+			   '+: "PLUS",
+			   "with space": "WITH SPACE",
+			 }.items`,
+			&object.PanArr{Elems: []object.PanObject{
+				&object.PanArr{Elems: []object.PanObject{
+					object.NewPanStr("a"),
+					object.NewPanStr("A"),
+				}},
+			}},
+		},
+		// with private keys (private keys follow public keys)
+		{
+			`{
+			   a: "A",
+			   _b: "_B",
+			   '+: "PLUS",
+			   "with space": "WITH SPACE",
+			 }.items(private?: true)`,
+			&object.PanArr{Elems: []object.PanObject{
+				&object.PanArr{Elems: []object.PanObject{
+					object.NewPanStr("a"),
+					object.NewPanStr("A"),
+				}},
+				&object.PanArr{Elems: []object.PanObject{
+					object.NewPanStr("+"),
+					object.NewPanStr("PLUS"),
+				}},
+				&object.PanArr{Elems: []object.PanObject{
+					object.NewPanStr("_b"),
+					object.NewPanStr("_B"),
+				}},
+				&object.PanArr{Elems: []object.PanObject{
+					object.NewPanStr("with space"),
+					object.NewPanStr("WITH SPACE"),
+				}},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		actual := testEval(t, tt.input)
+		testValue(t, actual, tt.expected)
+	}
+}
+
 func TestEvalStringify(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -2415,6 +2415,47 @@ func TestEvalBearContents(t *testing.T) {
 	}
 }
 
+func TestEvalObjKeys(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected object.PanObject
+	}{
+		{
+			`{}.keys`,
+			&object.PanArr{Elems: []object.PanObject{}},
+		},
+		{
+			`{a: 1, b: 2}.keys`,
+			&object.PanArr{Elems: []object.PanObject{
+				object.NewPanStr("a"),
+				object.NewPanStr("b"),
+			}},
+		},
+		// private keys are ignored
+		{
+			`{a: 1, _b: 2, '+: 3, "with space": 4}.keys`,
+			&object.PanArr{Elems: []object.PanObject{
+				object.NewPanStr("a"),
+			}},
+		},
+		// with private keys (private keys follow public keys)
+		{
+			`{a: 1, _b: 2, '+: 3, "with space": 4}.keys(private?: true)`,
+			&object.PanArr{Elems: []object.PanObject{
+				object.NewPanStr("a"),
+				object.NewPanStr("+"),
+				object.NewPanStr("_b"),
+				object.NewPanStr("with space"),
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		actual := testEval(t, tt.input)
+		testValue(t, actual, tt.expected)
+	}
+}
+
 func TestEvalStringify(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -2456,6 +2456,57 @@ func TestEvalObjKeys(t *testing.T) {
 	}
 }
 
+func TestEvalObjValues(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected object.PanObject
+	}{
+		{
+			`{}.values`,
+			&object.PanArr{Elems: []object.PanObject{}},
+		},
+		{
+			`{a: "A", b: "B"}.values`,
+			&object.PanArr{Elems: []object.PanObject{
+				object.NewPanStr("A"),
+				object.NewPanStr("B"),
+			}},
+		},
+		// private keys are ignored
+		{
+			`{
+			   a: "A",
+			   _b: "_B",
+			   '+: "PLUS",
+			   "with space": "WITH SPACE",
+			 }.values`,
+			&object.PanArr{Elems: []object.PanObject{
+				object.NewPanStr("A"),
+			}},
+		},
+		// with private keys (private keys follow public keys)
+		{
+			`{
+			   a: "A",
+			   _b: "_B",
+			   '+: "PLUS",
+			   "with space": "WITH SPACE",
+			 }.values(private?: true)`,
+			&object.PanArr{Elems: []object.PanObject{
+				object.NewPanStr("A"),
+				object.NewPanStr("PLUS"),
+				object.NewPanStr("_B"),
+				object.NewPanStr("WITH SPACE"),
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		actual := testEval(t, tt.input)
+		testValue(t, actual, tt.expected)
+	}
+}
+
 func TestEvalStringify(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/object/builtinobj.go
+++ b/object/builtinobj.go
@@ -3,21 +3,21 @@ package object
 // initialize built-in objects like Int, Arr, Str...
 // NOTE: Props are inserted in package eval not to make
 // package object and package BuiltIn circular reference
-var BuiltInIntObj = &PanObj{&map[SymHash]Pair{}, BuiltInNumObj}
-var BuiltInFloatObj = &PanObj{&map[SymHash]Pair{}, BuiltInNumObj}
-var BuiltInNumObj = &PanObj{&map[SymHash]Pair{}, BuiltInObjObj}
-var BuiltInNilObj = &PanObj{&map[SymHash]Pair{}, BuiltInObjObj}
-var BuiltInStrObj = &PanObj{&map[SymHash]Pair{}, BuiltInObjObj}
-var BuiltInArrObj = &PanObj{&map[SymHash]Pair{}, BuiltInObjObj}
-var BuiltInRangeObj = &PanObj{&map[SymHash]Pair{}, BuiltInObjObj}
+var BuiltInIntObj = NewPanObj(&map[SymHash]Pair{}, BuiltInNumObj)
+var BuiltInFloatObj = NewPanObj(&map[SymHash]Pair{}, BuiltInNumObj)
+var BuiltInNumObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInNilObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInStrObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInArrObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInRangeObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
 
-var BuiltInFuncObj = &PanObj{&map[SymHash]Pair{}, BuiltInObjObj}
-var BuiltInIterObj = &PanObj{&map[SymHash]Pair{}, BuiltInObjObj}
-var BuiltInMatchObj = &PanObj{&map[SymHash]Pair{}, BuiltInObjObj}
-var BuiltInObjObj = &PanObj{&map[SymHash]Pair{}, BuiltInBaseObj}
-var BuiltInBaseObj = &PanObj{&map[SymHash]Pair{}, nil}
-var BuiltInMapObj = &PanObj{&map[SymHash]Pair{}, BuiltInObjObj}
-var BuiltInIOObj = &PanObj{&map[SymHash]Pair{}, BuiltInObjObj}
+var BuiltInFuncObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInIterObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInMatchObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInObjObj = NewPanObj(&map[SymHash]Pair{}, BuiltInBaseObj)
+var BuiltInBaseObj = NewPanObj(&map[SymHash]Pair{}, nil)
+var BuiltInMapObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInIOObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
 
 var BuiltInOneInt = &PanInt{1}
 var BuiltInZeroInt = &PanInt{0}
@@ -27,14 +27,14 @@ var BuiltInFalse = &PanBool{false}
 var BuiltInNil = &PanNil{}
 
 // error hierarchy
-var BuiltInErrObj = &PanObj{&map[SymHash]Pair{}, BuiltInObjObj}
+var BuiltInErrObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
 
-var BuiltInAssertionErr = &PanObj{&map[SymHash]Pair{}, BuiltInErrObj}
-var BuiltInNameErr = &PanObj{&map[SymHash]Pair{}, BuiltInErrObj}
-var BuiltInNoPropErr = &PanObj{&map[SymHash]Pair{}, BuiltInErrObj}
-var BuiltInNotImplementedErr = &PanObj{&map[SymHash]Pair{}, BuiltInErrObj}
-var BuiltInStopIterErr = &PanObj{&map[SymHash]Pair{}, BuiltInErrObj}
-var BuiltInSyntaxErr = &PanObj{&map[SymHash]Pair{}, BuiltInErrObj}
-var BuiltInTypeErr = &PanObj{&map[SymHash]Pair{}, BuiltInErrObj}
-var BuiltInValueErr = &PanObj{&map[SymHash]Pair{}, BuiltInErrObj}
-var BuiltInZeroDivisionErr = &PanObj{&map[SymHash]Pair{}, BuiltInErrObj}
+var BuiltInAssertionErr = NewPanObj(&map[SymHash]Pair{}, BuiltInErrObj)
+var BuiltInNameErr = NewPanObj(&map[SymHash]Pair{}, BuiltInErrObj)
+var BuiltInNoPropErr = NewPanObj(&map[SymHash]Pair{}, BuiltInErrObj)
+var BuiltInNotImplementedErr = NewPanObj(&map[SymHash]Pair{}, BuiltInErrObj)
+var BuiltInStopIterErr = NewPanObj(&map[SymHash]Pair{}, BuiltInErrObj)
+var BuiltInSyntaxErr = NewPanObj(&map[SymHash]Pair{}, BuiltInErrObj)
+var BuiltInTypeErr = NewPanObj(&map[SymHash]Pair{}, BuiltInErrObj)
+var BuiltInValueErr = NewPanObj(&map[SymHash]Pair{}, BuiltInErrObj)
+var BuiltInZeroDivisionErr = NewPanObj(&map[SymHash]Pair{}, BuiltInErrObj)

--- a/object/obj_test.go
+++ b/object/obj_test.go
@@ -82,7 +82,81 @@ func TestObjProto(t *testing.T) {
 				tt.expectedName, tt.obj.Proto(), tt.obj.Proto())
 		}
 	}
+}
 
+func TestObjKeys(t *testing.T) {
+	tests := []struct {
+		obj      PanObject
+		expected []SymHash
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+			[]SymHash{},
+		},
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{
+				GetSymHash("a"): Pair{Key: NewPanStr("a"), Value: NewPanInt(1)},
+			}),
+			[]SymHash{
+				GetSymHash("a"),
+			},
+		},
+		// keys are ordered alphabetically
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{
+				GetSymHash("a"): Pair{Key: NewPanStr("a"), Value: NewPanInt(1)},
+				GetSymHash("b"): Pair{Key: NewPanStr("b"), Value: NewPanInt(2)},
+			}),
+			[]SymHash{
+				GetSymHash("a"),
+				GetSymHash("b"),
+			},
+		},
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{
+				GetSymHash("c"): Pair{Key: NewPanStr("c"), Value: NewPanInt(1)},
+				GetSymHash("b"): Pair{Key: NewPanStr("b"), Value: NewPanInt(1)},
+			}),
+			[]SymHash{
+				GetSymHash("b"),
+				GetSymHash("c"),
+			},
+		},
+		// keys only contain public str
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{
+				GetSymHash("a"):  Pair{Key: NewPanStr("a"), Value: NewPanInt(1)},
+				GetSymHash("=="): Pair{Key: NewPanStr("=="), Value: NewPanInt(2)},
+				GetSymHash("_b"): Pair{Key: NewPanStr("_b"), Value: NewPanInt(3)},
+				GetSymHash("c "): Pair{Key: NewPanStr("c "), Value: NewPanInt(4)},
+				GetSymHash("d"):  Pair{Key: NewPanStr("d"), Value: NewPanInt(5)},
+			}),
+			[]SymHash{
+				GetSymHash("a"),
+				GetSymHash("d"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		obj, ok := tt.obj.(*PanObj)
+		if !ok {
+			t.Fatalf("obj is not PanObj. got=%T(%s)",
+				tt.obj, tt.obj.Type())
+		}
+
+		if len(*obj.Keys) != len(tt.expected) {
+			t.Fatalf("wrong keys length: expected=%d, got=%d",
+				len(tt.expected), len(*obj.Keys))
+		}
+
+		for i, key := range *obj.Keys {
+			if key != tt.expected[i] {
+				t.Errorf("keys[%d] in %s is wrong. expected=%d, got=%d",
+					i, tt.obj.Inspect(), tt.expected[i], key)
+			}
+		}
+	}
 }
 
 // checked by compiler (this function works nothing)

--- a/props/obj_props.go
+++ b/props/obj_props.go
@@ -160,6 +160,39 @@ func ObjProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 				return object.NewPanStr(formattedStr(args[0]))
 			},
 		),
+		"values": f(
+			func(
+				env *object.Env, kwargs *object.PanObj, args ...object.PanObject,
+			) object.PanObject {
+				if len(args) < 1 {
+					return object.NewTypeErr("Obj#values requires at least 1 arg")
+				}
+
+				withPrivate := false
+				if pair, ok := propIn(kwargs, "private?"); ok {
+					withPrivate = (pair.Value == object.BuiltInTrue)
+				}
+
+				self, ok := traceProtoOf(args[0], isObj)
+				if !ok {
+					return &object.PanArr{Elems: []object.PanObject{}}
+				}
+				obj, _ := self.(*object.PanObj)
+
+				values := []object.PanObject{}
+				for _, keyHash := range *obj.Keys {
+					values = append(values, (*obj.Pairs)[keyHash].Value)
+				}
+
+				if withPrivate {
+					for _, keyHash := range *obj.PrivateKeys {
+						values = append(values, (*obj.Pairs)[keyHash].Value)
+					}
+				}
+
+				return &object.PanArr{Elems: values}
+			},
+		),
 	}
 }
 

--- a/props/obj_props.go
+++ b/props/obj_props.go
@@ -68,6 +68,47 @@ func ObjProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 			},
 		),
 		"callProp": propContainer["Obj_callProp"],
+		"items": f(
+			func(
+				env *object.Env, kwargs *object.PanObj, args ...object.PanObject,
+			) object.PanObject {
+				if len(args) < 1 {
+					return object.NewTypeErr("Obj#values requires at least 1 arg")
+				}
+
+				withPrivate := false
+				if pair, ok := propIn(kwargs, "private?"); ok {
+					withPrivate = (pair.Value == object.BuiltInTrue)
+				}
+
+				self, ok := traceProtoOf(args[0], isObj)
+				if !ok {
+					return &object.PanArr{Elems: []object.PanObject{}}
+				}
+				obj, _ := self.(*object.PanObj)
+
+				items := []object.PanObject{}
+				for _, keyHash := range *obj.Keys {
+					pair, _ := (*obj.Pairs)[keyHash]
+					items = append(items, &object.PanArr{Elems: []object.PanObject{
+						pair.Key,
+						pair.Value,
+					}})
+				}
+
+				if withPrivate {
+					for _, keyHash := range *obj.PrivateKeys {
+						pair, _ := (*obj.Pairs)[keyHash]
+						items = append(items, &object.PanArr{Elems: []object.PanObject{
+							pair.Key,
+							pair.Value,
+						}})
+					}
+				}
+
+				return &object.PanArr{Elems: items}
+			},
+		),
 		"keys": f(
 			func(
 				env *object.Env, kwargs *object.PanObj, args ...object.PanObject,

--- a/props/obj_props.go
+++ b/props/obj_props.go
@@ -68,6 +68,39 @@ func ObjProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 			},
 		),
 		"callProp": propContainer["Obj_callProp"],
+		"keys": f(
+			func(
+				env *object.Env, kwargs *object.PanObj, args ...object.PanObject,
+			) object.PanObject {
+				if len(args) < 1 {
+					return object.NewTypeErr("Obj#keys requires at least 1 arg")
+				}
+
+				withPrivate := false
+				if pair, ok := propIn(kwargs, "private?"); ok {
+					withPrivate = (pair.Value == object.BuiltInTrue)
+				}
+
+				self, ok := traceProtoOf(args[0], isObj)
+				if !ok {
+					return &object.PanArr{Elems: []object.PanObject{}}
+				}
+				obj, _ := self.(*object.PanObj)
+
+				keys := []object.PanObject{}
+				for _, keyHash := range *obj.Keys {
+					keys = append(keys, (*obj.Pairs)[keyHash].Key)
+				}
+
+				if withPrivate {
+					for _, keyHash := range *obj.PrivateKeys {
+						keys = append(keys, (*obj.Pairs)[keyHash].Key)
+					}
+				}
+
+				return &object.PanArr{Elems: keys}
+			},
+		),
 		"p": f(
 			func(
 				env *object.Env, kwargs *object.PanObj, args ...object.PanObject,

--- a/props/util.go
+++ b/props/util.go
@@ -57,3 +57,9 @@ func isRange(o object.PanObject) bool {
 func isStr(o object.PanObject) bool {
 	return o.Type() == object.STR_TYPE
 }
+
+func propIn(obj *object.PanObj, propName string) (object.Pair, bool) {
+	propSym := object.GetSymHash(propName)
+	pair, ok := (*obj.Pairs)[propSym]
+	return pair, ok
+}


### PR DESCRIPTION
enable to apply list and reduce chain to obj

```
{a: 1, b: 2}@{|k, v| "key: #{k}, value: #{v}".p}
# key: a, value: 1
# key: b, value: 2
```