### PR TITLE
refactor: move TraceProtoOf to object

### DIFF
--- a/object/traceproto.go
+++ b/object/traceproto.go
@@ -1,0 +1,127 @@
+package object
+
+func TraceProtoOfArr(obj PanObject) (*PanArr, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanArr); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfBool(obj PanObject) (*PanBool, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanBool); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfBuiltInFunc(obj PanObject) (*PanBuiltIn, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanBuiltIn); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfBuiltInIter(obj PanObject) (*PanBuiltInIter, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanBuiltInIter); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfFloat(obj PanObject) (*PanFloat, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanFloat); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfFunc(obj PanObject) (*PanFunc, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanFunc); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfInt(obj PanObject) (*PanInt, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanInt); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfIO(obj PanObject) (*PanIO, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanIO); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfMap(obj PanObject) (*PanMap, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanMap); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfMatch(obj PanObject) (*PanMatch, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanMatch); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfNil(obj PanObject) (*PanNil, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanNil); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfObj(obj PanObject) (*PanObj, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanObj); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfRange(obj PanObject) (*PanRange, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanRange); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func TraceProtoOfStr(obj PanObject) (*PanStr, bool) {
+	for o := obj; o.Proto() != nil; o = o.Proto() {
+		if v, ok := o.(*PanStr); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}

--- a/object/traceproto_test.go
+++ b/object/traceproto_test.go
@@ -1,0 +1,777 @@
+package object
+
+import (
+	"testing"
+)
+
+func TestTraceProtoOfArr(t *testing.T) {
+	proto := &PanArr{Elems: []PanObject{}}
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanArr
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfArr(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfArrFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfArr(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfBool(t *testing.T) {
+	proto := BuiltInFalse
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanBool
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfBool(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfBoolFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfBool(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfBuiltInFunc(t *testing.T) {
+	proto := &PanBuiltIn{}
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanBuiltIn
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfBuiltInFunc(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfBuiltInFuncFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfBuiltInFunc(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfBuiltInIter(t *testing.T) {
+	proto := &PanBuiltInIter{}
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanBuiltInIter
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfBuiltInIter(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfBuiltInIterFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfBuiltInIter(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfFloat(t *testing.T) {
+	proto := &PanFloat{Value: 0.0}
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanFloat
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfFloat(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfFloatFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfFloat(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfFunc(t *testing.T) {
+	proto := &PanFunc{}
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanFunc
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfFunc(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfFuncFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfFunc(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfInt(t *testing.T) {
+	proto := BuiltInOneInt
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanInt
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfInt(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfIntFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfInt(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfIO(t *testing.T) {
+	proto := &PanIO{}
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanIO
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfIO(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfIOFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfIO(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfMap(t *testing.T) {
+	proto := &PanMap{}
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanMap
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfMap(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfMapFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfMap(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfMatch(t *testing.T) {
+	proto := &PanMatch{}
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanMatch
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfMatch(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfMatchFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfMatch(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfNil(t *testing.T) {
+	proto := BuiltInNil
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanNil
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfNil(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfNilFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfNil(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfObj(t *testing.T) {
+	proto := BuiltInIntObj
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanObj
+	}{
+		// return proto
+		{
+			BuiltInOneInt,
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfObj(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfObjFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		// NOTE: all valid panobjects have OBJ_TYPE proto BuiltInBaseObj.
+		// In this test, Invaild err object (, whose proto is nil) is used.
+		{
+			&PanErr{},
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfObj(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfRange(t *testing.T) {
+	proto := &PanRange{}
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanRange
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfRange(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfRangeFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfRange(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfStr(t *testing.T) {
+	proto := &PanStr{Value: ""}
+
+	tests := []struct {
+		obj      PanObject
+		expected *PanStr
+	}{
+		// return proto
+		{
+			NewPanObj(&map[SymHash]Pair{}, proto),
+			proto,
+		},
+		// return itself
+		{
+			proto,
+			proto,
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfStr(tt.obj)
+
+		if !ok {
+			t.Errorf("ok must be true (obj=%v)", tt.obj)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
+				tt.expected, tt.expected, actual, actual)
+		}
+	}
+}
+
+func TestTraceProtoOfStrFailed(t *testing.T) {
+	tests := []struct {
+		obj PanObject
+	}{
+		{
+			PanObjInstancePtr(&map[SymHash]Pair{}),
+		},
+	}
+
+	for _, tt := range tests {
+		actual, ok := TraceProtoOfStr(tt.obj)
+
+		if ok {
+			t.Errorf("ok must be false (obj=%v)", tt.obj)
+		}
+
+		if actual != nil {
+			t.Errorf("actual must be nil. got=%+v(%T)", actual, actual)
+		}
+	}
+}

--- a/props/arr_props.go
+++ b/props/arr_props.go
@@ -21,17 +21,16 @@ func ArrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.BuiltInTrue
 				}
 
-				self, ok := traceProtoOf(args[0], isArr)
+				self, ok := object.TraceProtoOfArr(args[0])
 				if !ok {
 					return object.BuiltInFalse
 				}
-				other, ok := traceProtoOf(args[1], isArr)
+				other, ok := object.TraceProtoOfArr(args[1])
 				if !ok {
 					return object.BuiltInFalse
 				}
 
-				return compArrs(self.(*object.PanArr), other.(*object.PanArr),
-					propContainer, env)
+				return compArrs(self, other, propContainer, env)
 			},
 		),
 		"+": f(
@@ -42,22 +41,19 @@ func ArrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("+ requires at least 2 args")
 				}
 
-				self, ok := traceProtoOf(args[0], isArr)
+				self, ok := object.TraceProtoOfArr(args[0])
 				if !ok {
 					return object.NewTypeErr(
 						fmt.Sprintf("`%s` cannot be treated as arr", args[0].Inspect()))
 				}
-				other, ok := traceProtoOf(args[1], isArr)
+				other, ok := object.TraceProtoOfArr(args[1])
 				if !ok {
 					return object.NewTypeErr(
 						fmt.Sprintf("`%s` cannot be treated as arr", args[0].Inspect()))
 				}
 
 				// NOTE: no need to copy each elem because they are immutable
-				elems := append(
-					self.(*object.PanArr).Elems,
-					other.(*object.PanArr).Elems...,
-				)
+				elems := append(self.Elems, other.Elems...)
 				return &object.PanArr{Elems: elems}
 			},
 		),
@@ -69,14 +65,14 @@ func ArrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("* requires at least 2 args")
 				}
 
-				self, ok := traceProtoOf(args[0], isArr)
+				self, ok := object.TraceProtoOfArr(args[0])
 				if !ok {
 					return object.NewTypeErr(
 						fmt.Sprintf("`%s` cannot be treated as arr", args[0].Inspect()))
 				}
-				selfElems := self.(*object.PanArr).Elems
+				selfElems := self.Elems
 
-				other, ok := traceProtoOf(args[1], isInt)
+				other, ok := object.TraceProtoOfInt(args[1])
 				if !ok {
 					return object.NewTypeErr(
 						fmt.Sprintf("`%s` cannot be treated as int", args[0].Inspect()))
@@ -84,7 +80,7 @@ func ArrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 
 				// NOTE: no need to copy each elem because they are immutable
 				elems := []object.PanObject{}
-				for i := int64(0); i < other.(*object.PanInt).Value; i++ {
+				for i := int64(0); i < other.Value; i++ {
 					elems = append(elems, selfElems...)
 				}
 				return &object.PanArr{Elems: elems}
@@ -98,13 +94,13 @@ func ArrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("Arr#_iter requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isArr)
+				self, ok := object.TraceProtoOfArr(args[0])
 				if !ok {
 					return object.NewTypeErr("\\1 must be arr")
 				}
 
 				return &object.PanBuiltInIter{
-					Fn:  arrIter(self.(*object.PanArr)),
+					Fn:  arrIter(self),
 					Env: env, // not used
 				}
 			},
@@ -117,12 +113,12 @@ func ArrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 				if len(args) < 1 {
 					return object.NewTypeErr("Arr#B requires at least 1 arg")
 				}
-				self, ok := traceProtoOf(args[0], isArr)
+				self, ok := object.TraceProtoOfArr(args[0])
 				if !ok {
 					return object.NewTypeErr(`\1 must be arr`)
 				}
 
-				if len(self.(*object.PanArr).Elems) == 0 {
+				if len(self.Elems) == 0 {
 					return object.BuiltInFalse
 				}
 				return object.BuiltInTrue

--- a/props/float_props.go
+++ b/props/float_props.go
@@ -22,16 +22,16 @@ func FloatProps(propContainer map[string]object.PanObject) map[string]object.Pan
 					return object.BuiltInTrue
 				}
 
-				self, ok := traceProtoOf(args[0], isFloat)
+				self, ok := object.TraceProtoOfFloat(args[0])
 				if !ok {
 					return object.BuiltInFalse
 				}
-				other, ok := traceProtoOf(args[1], isFloat)
+				other, ok := object.TraceProtoOfFloat(args[1])
 				if !ok {
 					return object.BuiltInFalse
 				}
 
-				if self.(*object.PanFloat).Value == other.(*object.PanFloat).Value {
+				if self.Value == other.Value {
 					return object.BuiltInTrue
 				}
 				return object.BuiltInFalse
@@ -45,12 +45,12 @@ func FloatProps(propContainer map[string]object.PanObject) map[string]object.Pan
 					return object.NewTypeErr("\\- requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isFloat)
+				self, ok := object.TraceProtoOfFloat(args[0])
 				if !ok {
 					return object.NewTypeErr("\\1 must be float")
 				}
 
-				res := -self.(*object.PanFloat).Value
+				res := -self.Value
 				return &object.PanFloat{Value: res}
 			},
 		),
@@ -62,12 +62,12 @@ func FloatProps(propContainer map[string]object.PanObject) map[string]object.Pan
 					return object.NewTypeErr("/~ requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isFloat)
+				self, ok := object.TraceProtoOfFloat(args[0])
 				if !ok {
 					return object.NewTypeErr("\\1 must be float")
 				}
 
-				v := self.(*object.PanFloat).Value
+				v := self.Value
 				// NOTE: go cannot invert float bits directly
 				res := math.Float64frombits(^math.Float64bits(v))
 				return &object.PanFloat{Value: res}
@@ -81,18 +81,18 @@ func FloatProps(propContainer map[string]object.PanObject) map[string]object.Pan
 					return object.NewTypeErr("+ requires at least 2 args")
 				}
 
-				self, ok := traceProtoOf(args[0], isFloat)
+				self, ok := object.TraceProtoOfFloat(args[0])
 				if !ok {
 					return object.NewTypeErr(
-						fmt.Sprintf("`%s` cannot be treated as int", self.Inspect()))
+						fmt.Sprintf("`%s` cannot be treated as float", self.Inspect()))
 				}
-				other, ok := traceProtoOf(args[1], isFloat)
+				other, ok := object.TraceProtoOfFloat(args[1])
 				if !ok {
 					return object.NewTypeErr(
-						fmt.Sprintf("`%s` cannot be treated as int", other.Inspect()))
+						fmt.Sprintf("`%s` cannot be treated as float", other.Inspect()))
 				}
 
-				res := self.(*object.PanFloat).Value + other.(*object.PanFloat).Value
+				res := self.Value + other.Value
 				return &object.PanFloat{Value: res}
 			},
 		),
@@ -103,12 +103,12 @@ func FloatProps(propContainer map[string]object.PanObject) map[string]object.Pan
 				if len(args) < 1 {
 					return object.NewTypeErr("Float#B requires at least 1 arg")
 				}
-				self, ok := traceProtoOf(args[0], isFloat)
+				self, ok := object.TraceProtoOfFloat(args[0])
 				if !ok {
 					return object.NewTypeErr(`\1 must be float`)
 				}
 
-				if self.(*object.PanFloat).Value == 0.0 {
+				if self.Value == 0.0 {
 					return object.BuiltInFalse
 				}
 				return object.BuiltInTrue

--- a/props/func_props.go
+++ b/props/func_props.go
@@ -22,27 +22,26 @@ func FuncProps(propContainer map[string]object.PanObject) map[string]object.PanO
 				}
 
 				// func comparison
-				fn, ok := traceProtoOf(args[0], isFunc)
+				fn, ok := object.TraceProtoOfFunc(args[0])
 				if ok {
-					other, ok := traceProtoOf(args[1], isFunc)
+					other, ok := object.TraceProtoOfFunc(args[1])
 					if !ok {
 						return object.BuiltInFalse
 					}
-					return compFuncs(fn.(*object.PanFunc), other.(*object.PanFunc))
+					return compFuncs(fn, other)
 				}
 
 				// BuiltInFunc comparison
-				builtIn, ok := traceProtoOf(args[0], isBuiltInFunc)
+				builtIn, ok := object.TraceProtoOfBuiltInFunc(args[0])
 				if !ok {
 					return object.BuiltInFalse
 				}
-				other, ok := traceProtoOf(args[1], isBuiltInFunc)
+				other, ok := object.TraceProtoOfBuiltInFunc(args[1])
 				if !ok {
 					return object.BuiltInFalse
 				}
 
-				return compBuiltInFuncs(
-					builtIn.(*object.PanBuiltIn), other.(*object.PanBuiltIn))
+				return compBuiltInFuncs(builtIn, other)
 			},
 		),
 		"B": f(
@@ -52,7 +51,7 @@ func FuncProps(propContainer map[string]object.PanObject) map[string]object.PanO
 				if len(args) < 1 {
 					return object.NewTypeErr("Func#B requires at least 1 arg")
 				}
-				_, ok := traceProtoOf(args[0], isFunc)
+				_, ok := object.TraceProtoOfFunc(args[0])
 				if !ok {
 					return object.NewTypeErr(`\1 must be func`)
 				}

--- a/props/int_props.go
+++ b/props/int_props.go
@@ -17,8 +17,8 @@ func IntProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return err
 				}
 
-				selfVal := self.(*object.PanInt).Value
-				otherVal := other.(*object.PanInt).Value
+				selfVal := self.Value
+				otherVal := other.Value
 				var res int64
 
 				if selfVal > otherVal {
@@ -45,16 +45,16 @@ func IntProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.BuiltInTrue
 				}
 
-				self, ok := traceProtoOf(args[0], isInt)
+				self, ok := object.TraceProtoOfInt(args[0])
 				if !ok {
 					return object.BuiltInFalse
 				}
-				other, ok := traceProtoOf(args[1], isInt)
+				other, ok := object.TraceProtoOfInt(args[1])
 				if !ok {
 					return object.BuiltInFalse
 				}
 
-				if self.(*object.PanInt).Value == other.(*object.PanInt).Value {
+				if self.Value == other.Value {
 					return object.BuiltInTrue
 				}
 				return object.BuiltInFalse
@@ -74,16 +74,16 @@ func IntProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.BuiltInTrue
 				}
 
-				self, ok := traceProtoOf(args[0], isInt)
+				self, ok := object.TraceProtoOfInt(args[0])
 				if !ok {
 					return object.BuiltInFalse
 				}
-				other, ok := traceProtoOf(args[1], isInt)
+				other, ok := object.TraceProtoOfInt(args[1])
 				if !ok {
 					return object.BuiltInFalse
 				}
 
-				if self.(*object.PanInt).Value != other.(*object.PanInt).Value {
+				if self.Value != other.Value {
 					return object.BuiltInTrue
 				}
 				return object.BuiltInFalse
@@ -97,12 +97,12 @@ func IntProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("\\- requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isInt)
+				self, ok := object.TraceProtoOfInt(args[0])
 				if !ok {
 					return object.NewTypeErr("\\1 must be int")
 				}
 
-				res := -self.(*object.PanInt).Value
+				res := -self.Value
 				return object.NewPanInt(res)
 			},
 		),
@@ -114,12 +114,12 @@ func IntProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("/~ requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isInt)
+				self, ok := object.TraceProtoOfInt(args[0])
 				if !ok {
 					return object.NewTypeErr("\\1 must be int")
 				}
 
-				res := ^self.(*object.PanInt).Value
+				res := ^self.Value
 				return object.NewPanInt(res)
 			},
 		),
@@ -132,7 +132,7 @@ func IntProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return err
 				}
 
-				res := self.(*object.PanInt).Value + other.(*object.PanInt).Value
+				res := self.Value + other.Value
 				return object.NewPanInt(res)
 			},
 		),
@@ -145,7 +145,7 @@ func IntProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return err
 				}
 
-				res := self.(*object.PanInt).Value * other.(*object.PanInt).Value
+				res := self.Value * other.Value
 				return object.NewPanInt(res)
 			},
 		),
@@ -158,7 +158,7 @@ func IntProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return err
 				}
 
-				res := self.(*object.PanInt).Value + other.(*object.PanInt).Value
+				res := self.Value + other.Value
 				return object.NewPanInt(res)
 			},
 		),
@@ -170,13 +170,13 @@ func IntProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("Int#_iter requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isInt)
+				self, ok := object.TraceProtoOfInt(args[0])
 				if !ok {
 					return object.NewTypeErr("\\1 must be int")
 				}
 
 				return &object.PanBuiltInIter{
-					Fn:  intIter(self.(*object.PanInt)),
+					Fn:  intIter(self),
 					Env: env, // not used
 				}
 			},
@@ -189,12 +189,12 @@ func IntProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 				if len(args) < 1 {
 					return object.NewTypeErr("Int#B requires at least 1 arg")
 				}
-				self, ok := traceProtoOf(args[0], isInt)
+				self, ok := object.TraceProtoOfInt(args[0])
 				if !ok {
 					return object.NewTypeErr(`\1 must be int`)
 				}
 
-				if self.(*object.PanInt).Value == 0 {
+				if self.Value == 0 {
 					return object.BuiltInFalse
 				}
 				return object.BuiltInTrue
@@ -206,17 +206,17 @@ func IntProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 func checkIntInfixArgs(
 	args []object.PanObject,
 	propName string,
-) (object.PanObject, object.PanObject, *object.PanErr) {
+) (*object.PanInt, *object.PanInt, *object.PanErr) {
 	if len(args) < 2 {
 		return nil, nil, object.NewTypeErr(propName + " requires at least 2 args")
 	}
 
-	self, ok := traceProtoOf(args[0], isInt)
+	self, ok := object.TraceProtoOfInt(args[0])
 	if !ok {
 		return nil, nil, object.NewTypeErr(
 			fmt.Sprintf("`%s` cannot be treated as int", args[0].Inspect()))
 	}
-	other, ok := traceProtoOf(args[1], isInt)
+	other, ok := object.TraceProtoOfInt(args[1])
 	if !ok {
 		return nil, nil, object.NewTypeErr(
 			fmt.Sprintf("`%s` cannot be treated as int", args[1].Inspect()))

--- a/props/iter_props.go
+++ b/props/iter_props.go
@@ -21,16 +21,16 @@ func IterProps(propContainer map[string]object.PanObject) map[string]object.PanO
 				}
 
 				// same as func comparison
-				self, ok := traceProtoOf(args[0], isFunc)
+				self, ok := object.TraceProtoOfFunc(args[0])
 				if !ok {
 					return object.BuiltInFalse
 				}
-				other, ok := traceProtoOf(args[1], isFunc)
+				other, ok := object.TraceProtoOfFunc(args[1])
 				if !ok {
 					return object.BuiltInFalse
 				}
 
-				return compFuncs(self.(*object.PanFunc), other.(*object.PanFunc))
+				return compFuncs(self, other)
 			},
 		),
 		"_iter": f(
@@ -50,7 +50,7 @@ func IterProps(propContainer map[string]object.PanObject) map[string]object.PanO
 				if len(args) < 1 {
 					return object.NewTypeErr("Iter#B requires at least 1 arg")
 				}
-				_, ok := traceProtoOf(args[0], isFunc)
+				_, ok := object.TraceProtoOfFunc(args[0])
 				if !ok {
 					return object.NewTypeErr(`\1 must be func`)
 				}

--- a/props/map_props.go
+++ b/props/map_props.go
@@ -21,17 +21,16 @@ func MapProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.BuiltInTrue
 				}
 
-				self, ok := traceProtoOf(args[0], isMap)
+				self, ok := object.TraceProtoOfMap(args[0])
 				if !ok {
 					return object.BuiltInFalse
 				}
-				other, ok := traceProtoOf(args[1], isMap)
+				other, ok := object.TraceProtoOfMap(args[1])
 				if !ok {
 					return object.BuiltInFalse
 				}
 
-				return compMaps(self.(*object.PanMap), other.(*object.PanMap),
-					propContainer, env)
+				return compMaps(self, other, propContainer, env)
 			},
 		),
 		"_iter": f(
@@ -42,13 +41,13 @@ func MapProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("Map#_iter requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isMap)
+				self, ok := object.TraceProtoOfMap(args[0])
 				if !ok {
 					return object.NewTypeErr(`\1 must be map`)
 				}
 
 				return &object.PanBuiltInIter{
-					Fn:  mapIter(self.(*object.PanMap)),
+					Fn:  mapIter(self),
 					Env: env, // not used
 				}
 			},
@@ -61,13 +60,12 @@ func MapProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 				if len(args) < 1 {
 					return object.NewTypeErr("Map#B requires at least 1 arg")
 				}
-				self, ok := traceProtoOf(args[0], isMap)
+				self, ok := object.TraceProtoOfMap(args[0])
 				if !ok {
 					return object.NewTypeErr(`\1 must be map`)
 				}
 
-				m, _ := self.(*object.PanMap)
-				if len(*m.Pairs) == 0 && len(*m.NonHashablePairs) == 0 {
+				if len(*self.Pairs) == 0 && len(*self.NonHashablePairs) == 0 {
 					return object.BuiltInFalse
 				}
 				return object.BuiltInTrue
@@ -83,20 +81,19 @@ func MapProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("Map#items requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isMap)
+				self, ok := object.TraceProtoOfMap(args[0])
 				if !ok {
 					return &object.PanArr{Elems: []object.PanObject{}}
 				}
-				map_, _ := self.(*object.PanMap)
 
 				items := []object.PanObject{}
-				for _, pair := range *map_.Pairs {
+				for _, pair := range *self.Pairs {
 					items = append(items, &object.PanArr{Elems: []object.PanObject{
 						pair.Key,
 						pair.Value,
 					}})
 				}
-				for _, pair := range *map_.NonHashablePairs {
+				for _, pair := range *self.NonHashablePairs {
 					items = append(items, &object.PanArr{Elems: []object.PanObject{
 						pair.Key,
 						pair.Value,
@@ -116,17 +113,16 @@ func MapProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("Map#keys requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isMap)
+				self, ok := object.TraceProtoOfMap(args[0])
 				if !ok {
 					return &object.PanArr{Elems: []object.PanObject{}}
 				}
-				map_, _ := self.(*object.PanMap)
 
 				keys := []object.PanObject{}
-				for _, pair := range *map_.Pairs {
+				for _, pair := range *self.Pairs {
 					keys = append(keys, pair.Key)
 				}
-				for _, pair := range *map_.NonHashablePairs {
+				for _, pair := range *self.NonHashablePairs {
 					keys = append(keys, pair.Key)
 				}
 
@@ -143,17 +139,16 @@ func MapProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("Map#values requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isMap)
+				self, ok := object.TraceProtoOfMap(args[0])
 				if !ok {
 					return &object.PanArr{Elems: []object.PanObject{}}
 				}
-				map_, _ := self.(*object.PanMap)
 
 				values := []object.PanObject{}
-				for _, pair := range *map_.Pairs {
+				for _, pair := range *self.Pairs {
 					values = append(values, pair.Value)
 				}
-				for _, pair := range *map_.NonHashablePairs {
+				for _, pair := range *self.NonHashablePairs {
 					values = append(values, pair.Value)
 				}
 

--- a/props/nil_props.go
+++ b/props/nil_props.go
@@ -20,10 +20,10 @@ func NilProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.BuiltInTrue
 				}
 
-				if _, ok := traceProtoOf(args[0], isNil); !ok {
+				if _, ok := object.TraceProtoOfNil(args[0]); !ok {
 					return object.BuiltInFalse
 				}
-				if _, ok := traceProtoOf(args[1], isNil); !ok {
+				if _, ok := object.TraceProtoOfNil(args[1]); !ok {
 					return object.BuiltInFalse
 				}
 
@@ -37,7 +37,7 @@ func NilProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 				if len(args) < 1 {
 					return object.NewTypeErr("Nil#B requires at least 1 arg")
 				}
-				_, ok := traceProtoOf(args[0], isNil)
+				_, ok := object.TraceProtoOfNil(args[0])
 				if !ok {
 					return object.NewTypeErr(`\1 must be nil`)
 				}

--- a/props/obj_props.go
+++ b/props/obj_props.go
@@ -38,13 +38,13 @@ func ObjProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("Obj#_iter requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isObj)
+				self, ok := object.TraceProtoOfObj(args[0])
 				if !ok {
 					return object.NewTypeErr(`Obj#_iter cannot be applied to \1`)
 				}
 
 				return &object.PanBuiltInIter{
-					Fn:  objIter(self.(*object.PanObj)),
+					Fn:  objIter(self),
 					Env: env, // not used
 				}
 			},
@@ -56,12 +56,12 @@ func ObjProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 				if len(args) < 1 {
 					return object.NewTypeErr("Obj#B requires at least 1 arg")
 				}
-				self, ok := traceProtoOf(args[0], isObj)
+				self, ok := object.TraceProtoOfObj(args[0])
 				if !ok {
 					return object.NewTypeErr(`\1 must be obj`)
 				}
 
-				if len(*self.(*object.PanObj).Pairs) == 0 {
+				if len(*self.Pairs) == 0 {
 					return object.BuiltInFalse
 				}
 				return object.BuiltInTrue
@@ -81,15 +81,14 @@ func ObjProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					withPrivate = (pair.Value == object.BuiltInTrue)
 				}
 
-				self, ok := traceProtoOf(args[0], isObj)
+				self, ok := object.TraceProtoOfObj(args[0])
 				if !ok {
 					return &object.PanArr{Elems: []object.PanObject{}}
 				}
-				obj, _ := self.(*object.PanObj)
 
 				items := []object.PanObject{}
-				for _, keyHash := range *obj.Keys {
-					pair, _ := (*obj.Pairs)[keyHash]
+				for _, keyHash := range *self.Keys {
+					pair, _ := (*self.Pairs)[keyHash]
 					items = append(items, &object.PanArr{Elems: []object.PanObject{
 						pair.Key,
 						pair.Value,
@@ -97,8 +96,8 @@ func ObjProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 				}
 
 				if withPrivate {
-					for _, keyHash := range *obj.PrivateKeys {
-						pair, _ := (*obj.Pairs)[keyHash]
+					for _, keyHash := range *self.PrivateKeys {
+						pair, _ := (*self.Pairs)[keyHash]
 						items = append(items, &object.PanArr{Elems: []object.PanObject{
 							pair.Key,
 							pair.Value,
@@ -122,20 +121,19 @@ func ObjProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					withPrivate = (pair.Value == object.BuiltInTrue)
 				}
 
-				self, ok := traceProtoOf(args[0], isObj)
+				self, ok := object.TraceProtoOfObj(args[0])
 				if !ok {
 					return &object.PanArr{Elems: []object.PanObject{}}
 				}
-				obj, _ := self.(*object.PanObj)
 
 				keys := []object.PanObject{}
-				for _, keyHash := range *obj.Keys {
-					keys = append(keys, (*obj.Pairs)[keyHash].Key)
+				for _, keyHash := range *self.Keys {
+					keys = append(keys, (*self.Pairs)[keyHash].Key)
 				}
 
 				if withPrivate {
-					for _, keyHash := range *obj.PrivateKeys {
-						keys = append(keys, (*obj.Pairs)[keyHash].Key)
+					for _, keyHash := range *self.PrivateKeys {
+						keys = append(keys, (*self.Pairs)[keyHash].Key)
 					}
 				}
 
@@ -168,13 +166,13 @@ func ObjProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					object.EmptyPanObjPtr(), args[0], sSym,
 				)
 
-				str, ok := traceProtoOf(sRet, isStr)
+				str, ok := object.TraceProtoOfStr(sRet)
 				if !ok {
 					return object.NewTypeErr(`\1.S must be str`)
 				}
 
 				// print
-				io.WriteString(panIO.Out, str.(*object.PanStr).Value)
+				io.WriteString(panIO.Out, str.Value)
 				// breakline
 				io.WriteString(panIO.Out, "\n")
 
@@ -214,20 +212,19 @@ func ObjProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					withPrivate = (pair.Value == object.BuiltInTrue)
 				}
 
-				self, ok := traceProtoOf(args[0], isObj)
+				self, ok := object.TraceProtoOfObj(args[0])
 				if !ok {
 					return &object.PanArr{Elems: []object.PanObject{}}
 				}
-				obj, _ := self.(*object.PanObj)
 
 				values := []object.PanObject{}
-				for _, keyHash := range *obj.Keys {
-					values = append(values, (*obj.Pairs)[keyHash].Value)
+				for _, keyHash := range *self.Keys {
+					values = append(values, (*self.Pairs)[keyHash].Value)
 				}
 
 				if withPrivate {
-					for _, keyHash := range *obj.PrivateKeys {
-						values = append(values, (*obj.Pairs)[keyHash].Value)
+					for _, keyHash := range *self.PrivateKeys {
+						values = append(values, (*self.Pairs)[keyHash].Value)
 					}
 				}
 

--- a/props/str_props.go
+++ b/props/str_props.go
@@ -61,12 +61,12 @@ func StrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("/~ requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isStr)
+				self, ok := object.TraceProtoOfStr(args[0])
 				if !ok {
 					return object.NewTypeErr("\\1 must be str")
 				}
 
-				strBytes := []byte(self.(*object.PanStr).Value)
+				strBytes := []byte(self.Value)
 				negBytes := []byte{}
 				for _, b := range strBytes {
 					negBytes = append(negBytes, ^b)
@@ -96,18 +96,18 @@ func StrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("Str#_incBy requires at least 2 args")
 				}
 
-				self, ok := traceProtoOf(args[0], isStr)
+				self, ok := object.TraceProtoOfStr(args[0])
 				if !ok {
 					return object.NewTypeErr("\\1 must be str")
 				}
 
-				nInt, ok := traceProtoOf(args[1], isInt)
+				nInt, ok := object.TraceProtoOfInt(args[1])
 				if !ok {
 					return object.NewTypeErr("\\2 must be int")
 				}
-				n := nInt.(*object.PanInt).Value
+				n := nInt.Value
 
-				runes := []rune(self.(*object.PanStr).Value)
+				runes := []rune(self.Value)
 				increasedRune := runes[len(runes)-1] + rune(n)
 				newRunes := append(runes[0:len(runes)-1], increasedRune)
 
@@ -122,13 +122,13 @@ func StrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("Str#_iter requires at least 1 arg")
 				}
 
-				self, ok := traceProtoOf(args[0], isStr)
+				self, ok := object.TraceProtoOfStr(args[0])
 				if !ok {
 					return object.NewTypeErr("\\1 must be int")
 				}
 
 				return &object.PanBuiltInIter{
-					Fn:  strIter(self.(*object.PanStr)),
+					Fn:  strIter(self),
 					Env: env, // not used
 				}
 			},
@@ -141,12 +141,12 @@ func StrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 				if len(args) < 1 {
 					return object.NewTypeErr("Str#B requires at least 1 arg")
 				}
-				self, ok := traceProtoOf(args[0], isStr)
+				self, ok := object.TraceProtoOfStr(args[0])
 				if !ok {
 					return object.NewTypeErr(`\1 must be str`)
 				}
 
-				if self.(*object.PanStr).Value == "" {
+				if self.Value == "" {
 					return object.BuiltInFalse
 				}
 				return object.BuiltInTrue

--- a/props/util.go
+++ b/props/util.go
@@ -6,58 +6,6 @@ import (
 
 var eqSym = object.NewPanStr("==")
 
-func traceProtoOf(
-	obj object.PanObject,
-	cond func(object.PanObject) bool,
-) (object.PanObject, bool) {
-	for o := obj; o.Proto() != nil; o = o.Proto() {
-		if cond(o) {
-			return o, true
-		}
-	}
-	return nil, false
-}
-
-func isArr(o object.PanObject) bool {
-	return o.Type() == object.ARR_TYPE
-}
-
-func isBuiltInFunc(o object.PanObject) bool {
-	return o.Type() == object.BUILTIN_TYPE
-}
-
-func isFloat(o object.PanObject) bool {
-	return o.Type() == object.FLOAT_TYPE
-}
-
-func isFunc(o object.PanObject) bool {
-	return o.Type() == object.FUNC_TYPE
-}
-
-func isInt(o object.PanObject) bool {
-	return o.Type() == object.INT_TYPE
-}
-
-func isMap(o object.PanObject) bool {
-	return o.Type() == object.MAP_TYPE
-}
-
-func isNil(o object.PanObject) bool {
-	return o.Type() == object.NIL_TYPE
-}
-
-func isObj(o object.PanObject) bool {
-	return o.Type() == object.OBJ_TYPE
-}
-
-func isRange(o object.PanObject) bool {
-	return o.Type() == object.RANGE_TYPE
-}
-
-func isStr(o object.PanObject) bool {
-	return o.Type() == object.STR_TYPE
-}
-
 func propIn(obj *object.PanObj, propName string) (object.Pair, bool) {
 	propSym := object.GetSymHash(propName)
 	pair, ok := (*obj.Pairs)[propSym]


### PR DESCRIPTION
move `TraceProtoOf` functions from `props` package to `object` package so that they can be used in `evaluator` package