### PR TITLE
refactor: enable to use decendant objects for built-in funcs

### DIFF
--- a/evaluator/eval_embeddedstr.go
+++ b/evaluator/eval_embeddedstr.go
@@ -20,8 +20,7 @@ func evalEmbeddedStr(node *ast.EmbeddedStr, env *object.Env) object.PanObject {
 		evaluatedS := builtInCallProp(env, object.EmptyPanObjPtr(),
 			object.EmptyPanObjPtr(), evaluated, sSym)
 
-		// TODO: allow ancestor of str
-		evaluatedStr, ok := evaluatedS.(*object.PanStr)
+		evaluatedStr, ok := object.TraceProtoOfStr(evaluatedS)
 		if !ok {
 			err := object.NewValueErr(".S must return str")
 			return appendStackTrace(err, node.Source())

--- a/evaluator/eval_literalcall.go
+++ b/evaluator/eval_literalcall.go
@@ -16,8 +16,8 @@ func evalLiteralCall(node *ast.LiteralCallExpr, env *object.Env) object.PanObjec
 		return appendStackTrace(err, node.Source())
 	}
 
-	// TODO: handle ancestors of func
-	f, ok := fObj.(*object.PanFunc)
+	// TODO: duck typing (allow all objs with `call` prop)
+	f, ok := object.TraceProtoOfFunc(fObj)
 	if !ok {
 		err := object.NewTypeErr("literal call must be func")
 		return appendStackTrace(err, node.Source())
@@ -216,10 +216,12 @@ func _evalLiteralCall(
 }
 
 func literalCallArgs(recv object.PanObject, f *object.PanFunc) []object.PanObject {
-	// NOTE: extract elems
-	// TODO: handle ancestors of arr
-	if len(f.Args().Elems) > 1 && recv.Type() == object.ARR_TYPE {
-		return recv.(*object.PanArr).Elems
+	// NOTE: extract elems if there are more than 1 params and recv is arr
+	if len(f.Args().Elems) > 1 {
+		arr, ok := object.TraceProtoOfArr(recv)
+		if ok {
+			return arr.Elems
+		}
 	}
 
 	return []object.PanObject{recv}

--- a/evaluator/eval_obj.go
+++ b/evaluator/eval_obj.go
@@ -15,7 +15,8 @@ func evalObj(node *ast.ObjLiteral, env *object.Env) object.PanObject {
 			return appendStackTrace(err, node.Source())
 		}
 
-		panStr, ok := pair.Key.(*object.PanStr)
+		// NOTE: key must be str. if not, str proto is used instead
+		panStr, ok := object.TraceProtoOfStr(pair.Key)
 
 		if !ok {
 			err := object.NewTypeErr(
@@ -23,6 +24,8 @@ func evalObj(node *ast.ObjLiteral, env *object.Env) object.PanObject {
 			return appendStackTrace(err, node.Source())
 		}
 
+		// replace key with its str proto if it is not str
+		pair.Key = panStr
 		symHash := object.GetSymHash(panStr.Value)
 
 		// NOTE: ignore duplicated keys (`{a: 1, a: 2}` is same as `{a: 1}`)

--- a/evaluator/eval_pair.go
+++ b/evaluator/eval_pair.go
@@ -29,13 +29,13 @@ func evalObjPair(node *ast.Pair, env *object.Env) (object.Pair, *object.PanErr) 
 			return emptyPair, appendStackTrace(err, node.Val.Source())
 		}
 
-		// TODO: allow ancestors of str
-		if k.Type() != object.STR_TYPE {
+		strK, ok := object.TraceProtoOfStr(k)
+		if !ok {
 			err := object.NewTypeErr("key of obj must be str")
 			return emptyPair, appendStackTrace(err, node.Val.Source())
 		}
 
-		return object.Pair{Key: k, Value: v}, nil
+		return object.Pair{Key: strK, Value: v}, nil
 	}
 
 	k := Eval(node.Key, env)

--- a/evaluator/eval_varcall.go
+++ b/evaluator/eval_varcall.go
@@ -16,8 +16,8 @@ func evalVarCall(node *ast.VarCallExpr, env *object.Env) object.PanObject {
 		return appendStackTrace(err, node.Source())
 	}
 
-	// TODO: handle ancestors of func
-	f, ok := fObj.(*object.PanFunc)
+	// TODO: duck typing (allow all objs with `call` prop)
+	f, ok := object.TraceProtoOfFunc(fObj)
 	if !ok {
 		err := object.NewTypeErr("var call must be func")
 		return appendStackTrace(err, node.Source())

--- a/evaluator/expansion.go
+++ b/evaluator/expansion.go
@@ -27,9 +27,8 @@ func unpackArrExpansion(
 		return nil, appendStackTrace(err, pref.Source()), true
 	}
 
-	arr, ok := evaluated.(*object.PanArr)
+	arr, ok := object.TraceProtoOfArr(evaluated)
 
-	// TODO: error handling if evaluated is not *PanArr
 	if !ok {
 		err := object.NewTypeErr(
 			fmt.Sprintf("cannot use `*` unpacking for `%s`", evaluated.Inspect()))

--- a/evaluator/index.go
+++ b/evaluator/index.go
@@ -15,14 +15,14 @@ func findElemInArr(
 	if len(args) < 2 {
 		return object.NewTypeErr("Arr#at requires at least 2 args")
 	}
-	// TODO: duck typing for keys (allow child of arr)
-	self, ok := args[0].(*object.PanArr)
+	// NOTE: allow descendant of arr
+	self, ok := object.TraceProtoOfArr(args[0])
 	if !ok {
 		return object.BuiltInNil
 	}
 
-	// TODO: duck typing for keys (allow child of arr)
-	indexArr, ok := args[1].(*object.PanArr)
+	// NOTE: allow descendant of arr
+	indexArr, ok := object.TraceProtoOfArr(args[1])
 	if !ok {
 		return object.BuiltInNil
 	}
@@ -31,15 +31,17 @@ func findElemInArr(
 		return object.BuiltInNil
 	}
 
-	switch index := indexArr.Elems[0].(type) {
-	case *object.PanInt:
-		// TODO: duck typing for keys (allow child of int)
+	if index, ok := object.TraceProtoOfInt(indexArr.Elems[0]); ok {
+		// allow child of int
 		return arrIndex(index.Value, self)
-	case *object.PanRange:
-		return arrRange(index, self)
-	default:
-		return findElemInObj(env, kwargs, args...)
 	}
+
+	if index, ok := object.TraceProtoOfRange(indexArr.Elems[0]); ok {
+		// allow child of range
+		return arrRange(index, self)
+	}
+
+	return findElemInObj(env, kwargs, args...)
 }
 
 func findBitInInt(
@@ -52,14 +54,14 @@ func findBitInInt(
 	if len(args) < 2 {
 		return object.NewTypeErr("Int#at requires at least 2 args")
 	}
-	// TODO: duck typing for keys (allow child of arr)
-	self, ok := args[0].(*object.PanInt)
+	// allow child of int
+	self, ok := object.TraceProtoOfInt(args[0])
 	if !ok {
 		return object.BuiltInNil
 	}
 
-	// TODO: duck typing for keys (allow child of arr)
-	indexArr, ok := args[1].(*object.PanArr)
+	// allow child of arr
+	indexArr, ok := object.TraceProtoOfArr(args[1])
 	if !ok {
 		return object.BuiltInNil
 	}
@@ -68,15 +70,15 @@ func findBitInInt(
 		return object.BuiltInNil
 	}
 
-	switch index := indexArr.Elems[0].(type) {
-	case *object.PanInt:
-		// TODO: duck typing for keys (allow child of int)
+	if index, ok := object.TraceProtoOfInt(indexArr.Elems[0]); ok {
 		return intIndex(index.Value, self.Value)
-	case *object.PanRange:
-		return intRange(index, self.Value)
-	default:
-		return findElemInObj(env, kwargs, args...)
 	}
+
+	if index, ok := object.TraceProtoOfRange(indexArr.Elems[0]); ok {
+		return intRange(index, self.Value)
+	}
+
+	return findElemInObj(env, kwargs, args...)
 }
 
 func findElemInObj(
@@ -89,8 +91,8 @@ func findElemInObj(
 	}
 	self := args[0]
 
-	// TODO: duck typing for keys (allow child of arr)
-	indexArr, ok := args[1].(*object.PanArr)
+	// allow child of arr
+	indexArr, ok := object.TraceProtoOfArr(args[1])
 	if !ok {
 		return object.BuiltInNil
 	}
@@ -99,8 +101,8 @@ func findElemInObj(
 		return object.BuiltInNil
 	}
 
-	// TODO: duck typing for keys (allow child of str)
-	propName, ok := indexArr.Elems[0].(*object.PanStr)
+	// allow child of str
+	propName, ok := object.TraceProtoOfStr(indexArr.Elems[0])
 	if !ok {
 		return object.BuiltInNil
 	}
@@ -123,14 +125,14 @@ func findElemInStr(
 	if len(args) < 2 {
 		return object.NewTypeErr("Str#at requires at least 2 args")
 	}
-	// TODO: duck typing for keys (allow child of arr)
-	self, ok := args[0].(*object.PanStr)
+	// allow child of str
+	self, ok := object.TraceProtoOfStr(args[0])
 	if !ok {
 		return object.BuiltInNil
 	}
 
-	// TODO: duck typing for keys (allow child of arr)
-	indexArr, ok := args[1].(*object.PanArr)
+	// allow child of arr
+	indexArr, ok := object.TraceProtoOfArr(args[1])
 	if !ok {
 		return object.BuiltInNil
 	}
@@ -141,15 +143,15 @@ func findElemInStr(
 
 	runes := []rune(self.Value)
 
-	switch index := indexArr.Elems[0].(type) {
-	case *object.PanInt:
-		// TODO: duck typing for keys (allow child of int)
+	if index, ok := object.TraceProtoOfInt(indexArr.Elems[0]); ok {
 		return strIndex(index.Value, runes)
-	case *object.PanRange:
-		return strRange(index, runes)
-	default:
-		return findElemInObj(env, kwargs, args...)
 	}
+
+	if index, ok := object.TraceProtoOfRange(indexArr.Elems[0]); ok {
+		return strRange(index, runes)
+	}
+
+	return findElemInObj(env, kwargs, args...)
 }
 
 func arrIndex(index int64, arr *object.PanArr) object.PanObject {
@@ -310,14 +312,14 @@ func findElemInMap(
 		return object.NewTypeErr("Obj#at requires at least 2 args")
 	}
 
-	// TODO: duck typing for keys (allow child of map)
-	self, ok := args[0].(*object.PanMap)
+	// allow child of map
+	self, ok := object.TraceProtoOfMap(args[0])
 	if !ok {
 		return object.BuiltInNil
 	}
 
-	// TODO: duck typing for keys (allow child of arr)
-	indexArr, ok := args[1].(*object.PanArr)
+	// allow child of arr
+	indexArr, ok := object.TraceProtoOfArr(args[1])
 	if !ok {
 		return object.BuiltInNil
 	}

--- a/evaluator/iternew.go
+++ b/evaluator/iternew.go
@@ -14,8 +14,8 @@ func iterNew(
 		return object.NewTypeErr("Iter#new requires at least 1 arg")
 	}
 
-	// TODO: enable to use ansectors of iter
-	self, ok := args[0].(*object.PanFunc)
+	// allow descendant of iter
+	self, ok := object.TraceProtoOfFunc(args[0])
 	if !ok {
 		return object.NewTypeErr("\\1 must be iter")
 	}

--- a/parser/y_test.go
+++ b/parser/y_test.go
@@ -2127,7 +2127,6 @@ func TestCallWithArgs(t *testing.T) {
 		{`5=$hi(6)`, 5, "hi", []interface{}{6}},
 	}
 
-	// TODO: inplement test
 	for _, tt := range tests {
 		program := testParse(t, tt.input)
 		expr := extractExprStmt(t, program)


### PR DESCRIPTION
for example, these exprs got acceptable

```
[1, 2][false] # 1
[1, *([2, 3].bear)] # [1, 2, 3]
```