### PR TITLE
refactor: fix bugs of Obj#items

### DIFF
--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -2804,6 +2804,13 @@ func TestEvalObjKeys(t *testing.T) {
 				object.NewPanStr("with space"),
 			}},
 		},
+		// child of obj
+		{
+			`{a: 1}.bear({b: 2}).keys`,
+			&object.PanArr{Elems: []object.PanObject{
+				object.NewPanStr("b"),
+			}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2853,6 +2860,13 @@ func TestEvalObjValues(t *testing.T) {
 				object.NewPanStr("PLUS"),
 				object.NewPanStr("_B"),
 				object.NewPanStr("WITH SPACE"),
+			}},
+		},
+		// child of obj
+		{
+			`{a: 1}.bear({b: 2}).values`,
+			&object.PanArr{Elems: []object.PanObject{
+				object.NewPanInt(2),
 			}},
 		},
 	}
@@ -2924,6 +2938,16 @@ func TestEvalObjItems(t *testing.T) {
 				&object.PanArr{Elems: []object.PanObject{
 					object.NewPanStr("with space"),
 					object.NewPanStr("WITH SPACE"),
+				}},
+			}},
+		},
+		// child of obj
+		{
+			`{a: 1}.bear({b: 2}).items`,
+			&object.PanArr{Elems: []object.PanObject{
+				&object.PanArr{Elems: []object.PanObject{
+					object.NewPanStr("b"),
+					object.NewPanInt(2),
 				}},
 			}},
 		},

--- a/object/obj.go
+++ b/object/obj.go
@@ -45,7 +45,12 @@ func EmptyPanObjPtr() *PanObj {
 // ChildPanObjPtr makes new child object of proto with props in src.
 func ChildPanObjPtr(proto PanObject, src *PanObj) *PanObj {
 	// share pairs with src because objects are immutable
-	i := PanObj{Pairs: src.Pairs, proto: proto}
+	i := PanObj{
+		Pairs:       src.Pairs,
+		Keys:        src.Keys,
+		PrivateKeys: src.PrivateKeys,
+		proto:       proto,
+	}
 	return &i
 }
 


### PR DESCRIPTION
fix bug that the code below crashes

```
{a: 1}.bear.keys
{a: 1}.bear.values
{a: 1}.bear.items
```