### PR TITLE
refactor: add pairs to obj by PanObj#AddPairs

### DIFF
--- a/di/container.go
+++ b/di/container.go
@@ -45,13 +45,17 @@ func injectProps(
 	propContainers ...map[string]object.PanObject,
 ) {
 	ctn := mergePropContainers(propContainers...)
-	for propName, propVal := range ctn {
-		propHash := object.GetSymHash(propName)
-		(*obj.Pairs)[propHash] = object.Pair{
-			Key:   object.NewPanStr(propName),
-			Value: propVal,
+	pairs := map[object.SymHash]object.Pair{}
+
+	for k, v := range ctn {
+		pair := object.Pair{
+			Key:   object.NewPanStr(k),
+			Value: v,
 		}
+		pairs[object.GetSymHash(k)] = pair
 	}
+
+	obj.AddPairs(&pairs)
 }
 
 func mergePropContainers(

--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -47,13 +47,16 @@ func injectProps(
 	props func(map[string]object.PanObject) map[string]object.PanObject,
 	propContainer map[string]object.PanObject,
 ) {
-	for propName, propVal := range props(propContainer) {
-		propHash := object.GetSymHash(propName)
-		(*obj.Pairs)[propHash] = object.Pair{
-			Key:   object.NewPanStr(propName),
-			Value: propVal,
+	pairs := map[object.SymHash]object.Pair{}
+	for k, v := range props(propContainer) {
+		pair := object.Pair{
+			Key:   object.NewPanStr(k),
+			Value: v,
 		}
+		pairs[object.GetSymHash(k)] = pair
 	}
+
+	obj.AddPairs(&pairs)
 }
 
 func TestEvalIntLiteral(t *testing.T) {

--- a/object/obj.go
+++ b/object/obj.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"bytes"
+	"errors"
 	"sort"
 )
 
@@ -123,4 +124,26 @@ func keyHashes(pairs *map[SymHash]Pair) ([]SymHash, []SymHash) {
 	}
 
 	return publicHashes, privateHashes
+}
+
+// AddPairs adds pairs to obj.
+// NOTE: Use this method only for prop DI. Otherwise immutability gets broken.
+func (o *PanObj) AddPairs(pairs *map[SymHash]Pair) error {
+	if pairs == nil {
+		return errors.New("pairs must not be nil")
+	}
+
+	// add new pairs
+	for k, v := range *pairs {
+		// set only if prop does not exist
+		if _, ok := (*o.Pairs)[k]; !ok {
+			(*o.Pairs)[k] = v
+		}
+	}
+
+	// update keys
+	publicKeys, privateKeys := keyHashes(o.Pairs)
+	o.Keys = &publicKeys
+	o.PrivateKeys = &privateKeys
+	return nil
 }


### PR DESCRIPTION
props `keys` , `values`, and `items` can work for built-in objects