### PR TITLE
Add kernel init

### DIFF
--- a/di/container.go
+++ b/di/container.go
@@ -68,6 +68,10 @@ func injectBuiltInProps(
 	go func() {
 		iterableNativesCh <- mustReadNativeCode("Iterable", env)
 	}()
+	kernelNativesCh := make(chan *map[object.SymHash]object.Pair)
+	go func() {
+		kernelNativesCh <- mustReadNativeCode("Kernel", env)
+	}()
 	objNativesCh := make(chan *map[object.SymHash]object.Pair)
 	go func() {
 		objNativesCh <- mustReadNativeCode("Obj", env)
@@ -94,6 +98,7 @@ func injectBuiltInProps(
 	intNatives := <-intNativesCh
 	iterNatives := <-iterNativesCh
 	iterableNatives := <-iterableNativesCh
+	kernelNatives := <-kernelNativesCh
 	objNatives := <-objNativesCh
 	rangeNatives := <-rangeNativesCh
 	strNatives := <-strNativesCh
@@ -114,7 +119,7 @@ func injectBuiltInProps(
 	injectProps(object.BuiltInIntObj, toPairs(props.IntProps(ctn)), intNatives, iterableNatives, comparableNatives)
 	injectProps(object.BuiltInIterObj, toPairs(props.IterProps(ctn)), iterNatives, iterableNatives)
 	injectProps(object.BuiltInIterableObj, toPairs(props.IterableProps(ctn)), iterableNatives)
-	injectProps(object.BuiltInKernelObj, toPairs(props.KernelProps(ctn)))
+	injectProps(object.BuiltInKernelObj, toPairs(props.KernelProps(ctn)), kernelNatives)
 	injectProps(object.BuiltInMatchObj, toPairs(props.MatchProps(ctn)))
 	injectProps(object.BuiltInMapObj, toPairs(props.MapProps(ctn)), iterableNatives)
 	injectProps(object.BuiltInNameErr, toPairs(props.NameErrProps(ctn)))

--- a/evaluator/eval_obj.go
+++ b/evaluator/eval_obj.go
@@ -2,6 +2,7 @@ package evaluator
 
 import (
 	"fmt"
+
 	"github.com/Syuparn/pangaea/ast"
 	"github.com/Syuparn/pangaea/object"
 )
@@ -51,8 +52,11 @@ func evalObj(node *ast.ObjLiteral, env *object.Env) object.PanObject {
 			return appendStackTrace(e, expElem.Source())
 		}
 
+		// NOTE: ignore duplicated keys
 		for symHash, pair := range *obj.Pairs {
-			pairMap[symHash] = pair
+			if _, exists := pairMap[symHash]; !exists {
+				pairMap[symHash] = pair
+			}
 		}
 	}
 

--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -1365,6 +1365,25 @@ func TestEvalObjLiteral(t *testing.T) {
 				},
 			}),
 		},
+		// dangling keys in embedded obj are also ignored
+		{
+			`{x: 1, **{x: 2}}`,
+			toPanObj([]object.Pair{
+				{
+					Key:   object.NewPanStr("x"),
+					Value: object.NewPanInt(1),
+				},
+			}),
+		},
+		{
+			`{**{y: 1}, **{y: 2}}`,
+			toPanObj([]object.Pair{
+				{
+					Key:   object.NewPanStr("y"),
+					Value: object.NewPanInt(1),
+				},
+			}),
+		},
 		// enable to use descendant of str for key (str proto is set)
 		{
 			`{"hoge".bear: 1}`,

--- a/native/Kernel.pangaea
+++ b/native/Kernel.pangaea
@@ -2,10 +2,12 @@
   # _init provides initializing constructor.
   _init: {
     params := \0
+    defaultKwargs := \_
     m{
       args := \0[1:]
       raise TypeErr.new("arity must be #{params.len}") if args.len != params.len
-      .bear(params.zip(args).A.O)
+      kwargs := \_@{|k, v| [k, v] if defaultKwargs.keys.has?(k)}.A.O
+      .bear({**params.zip(args).A.O, **kwargs, **defaultKwargs})
     }
   },
 }

--- a/native/Kernel.pangaea
+++ b/native/Kernel.pangaea
@@ -1,0 +1,11 @@
+{
+  # _init provides initializing constructor.
+  _init: {
+    params := \0
+    m{
+      args := \0[1:]
+      raise TypeErr.new("arity must be #{params.len}") if args.len != params.len
+      .bear(params.zip(args).A.O)
+    }
+  },
+}

--- a/tests/Kernel_init_test.pangaea
+++ b/tests/Kernel_init_test.pangaea
@@ -1,10 +1,16 @@
 MyObj := {
-  new: _init('a, 'b),
+  new: _init('a, 'b, c: 3),
 }
 
-assertEq(MyObj.new(1, 2), MyObj.bear({a: 1, b: 2}))
+assertEq(MyObj.new(1, 2), MyObj.bear({a: 1, b: 2, c: 3}))
 assertEq(MyObj.new(1, 2).proto, MyObj)
 
 # if arity is wrong
 assertRaises(TypeErr, "arity must be 2") {MyObj.new(1)}
 assertRaises(TypeErr, "arity must be 2") {MyObj.new(1, 2, 3)}
+
+# with kwargs
+assertEq(MyObj.new(1, 2, c: 4), MyObj.bear({a: 1, b: 2, c: 4}))
+# kwargs not contained in _init are ignored
+assertEq(MyObj.new(1, 2, other: 5), MyObj.bear({a: 1, b: 2, c: 3}))
+

--- a/tests/Kernel_init_test.pangaea
+++ b/tests/Kernel_init_test.pangaea
@@ -1,0 +1,10 @@
+MyObj := {
+  new: _init('a, 'b),
+}
+
+assertEq(MyObj.new(1, 2), MyObj.bear({a: 1, b: 2}))
+assertEq(MyObj.new(1, 2).proto, MyObj)
+
+# if arity is wrong
+assertRaises(TypeErr, "arity must be 2") {MyObj.new(1)}
+assertRaises(TypeErr, "arity must be 2") {MyObj.new(1, 2, 3)}


### PR DESCRIPTION
short-hand obj constructor can be made by _init func

```
MyObj := {
  new: _init('a, 'b, c: 3),
  _name: 'MyObj
}

MyObj

>>> MyObj.new(1,2)
{"a": 1, "b": 2, "c": 3}
>>> MyObj.new(1,2).proto
MyObj
>>> MyObj.new(1,2, c: 4)
{"a": 1, "b": 2, "c": 4}
>>> MyObj.new(1)
TypeErr: arity must be 2
>>> MyObj.new(1,3,5)
TypeErr: arity must be 2
```