### PR TITLE
Add obj case

### DIFF
--- a/native/Comparable.pangaea
+++ b/native/Comparable.pangaea
@@ -1,8 +1,6 @@
 {
   # == returns whether self and other are equivalent.
   '==: m{|other| (self <=> other) == 0},
-  # != returns whether self and other are not equivalent.
-  '!=: m{|other| (self <=> other) != 0},
   # < returns whether self is smaller then other.
   '<: m{|other| (self <=> other) == -1},
   # <= returns whether self is not larger then other.

--- a/native/Obj.pangaea
+++ b/native/Obj.pangaea
@@ -4,7 +4,7 @@
   # !== returns whether predicate other is false as for the topic self.
   '!==: m{|other| !(self === other)},
   # ancestors returns all ancestors along the proto chain of self.
-  ancestors: m{<{yield \ if \ != nil; recur(.proto)}>.new(self).A[1:]},
+  ancestors: m{<{yield .proto if \ != BaseObj; recur(.proto)}>.new(self).A},
   # asFor? returns whether predicate self is true as for o.
   asFor?: m{|o| o.kindOf?(self)},
   # kindOf? returns whether other appears in self's proto chain.

--- a/native/Obj.pangaea
+++ b/native/Obj.pangaea
@@ -7,6 +7,8 @@
   ancestors: m{<{yield .proto if \ != BaseObj; recur(.proto)}>.new(self).A},
   # asFor? returns whether predicate self is true as for o.
   asFor?: m{|o| o.kindOf?(self)},
+  # case returns value of firstly matched key (or nil if not matched any).
+  case: m{|map| map.find {|k, v| self === k}.{|k, v| v}},
   # kindOf? returns whether other appears in self's proto chain.
   kindOf?: m{|other| self == other || .ancestors.has?(other)},
   # max returns the maximum value in self

--- a/native/Range.pangaea
+++ b/native/Range.pangaea
@@ -2,7 +2,7 @@
   # asFor? returns whether predicate self is true as for o.
   asFor?: m{|o| .find {\ == o}.nil?.!},
   # at returns elements of given indices.
-  at: m{|i| ._iter.at(i)},
+  at: m{|i| v if (v := Obj['at](self, i)).nil?.! else ._iter.at(i)},
   # counter? returns whether all of start, stop, and step are int.
   counter?: m{[.start, .stop, .step].all? {(.proto == Int) || .nil?}},
   # dec? returns whether self is a decresing range.

--- a/native/Str.pangaea
+++ b/native/Str.pangaea
@@ -2,7 +2,7 @@
   # IA converts self into int arr
   IA: m{|sep: `\s`| .split(sep: sep)@I},
   # asFor? returns whether predicate self is true as for o.
-  asFor?: m{|o| o.match(self).B},
+  asFor?: m{|o| nil~.{o.match(self)}.B},
   # call calls prop of obj whose key is self
   call: m{|obj| obj[self](obj) if .sym? else ValueErr.new("`#{self}` is not a symbol")},
   # camel makes self camelCase

--- a/tests/Obj_case_test.pangaea
+++ b/tests/Obj_case_test.pangaea
@@ -1,0 +1,21 @@
+assertEq(1.case(%{1: 'one}), 'one)
+
+# first match
+assertEq(2.case(%{
+  1: 'one,
+  2: 'two,
+  3: 'three,
+}), 'two)
+
+# kindOf match
+assertEq(1.case(%{
+  Str: 'str,
+  Int: 'int,
+}), 'int)
+
+# asFor? match
+assertEq("ABBC".case(%{
+  {.lc?}: 'lowercase,
+  "AB+": 'withAB,
+  Obj: 'others,
+}), 'withAB)

--- a/tests/Range_at_test.pangaea
+++ b/tests/Range_at_test.pangaea
@@ -7,3 +7,6 @@ assertEq((0:10:2)[4:1:-1], [8, 6, 4])
 assertEq((0:10:2)[0:0], [])
 assertEq((0:10:2)[4:], [8])
 assertEq((0:10:2)[:2], [0, 2])
+# props can be also referred
+assertEq((0:10:2)['_name], Obj['at](Range, ['_name]))
+assertEq((0:10:2)['at], Obj['at](Range, ['at]))

--- a/tests/Str_asForp_test.pangaea
+++ b/tests/Str_asForp_test.pangaea
@@ -2,3 +2,5 @@ assertEq("ab+".asFor?("abb"), true)
 assertEq("ab+".asFor?("abbc"), true)
 assertEq("^ab+$".asFor?("abc"), false)
 assertEq("a".asFor?("a"), true)
+# non-string value
+assertEq("a".asFor?(1), false)


### PR DESCRIPTION
matching method `Obj#case`, which uses `===` match

```
"ABBC".case(%{
  {.lc?}: 'lowercase,
  "AB+": 'withAB,
  Obj: 'others,
})

# "withAB"
```