### PR TITLE
native: add Arr#grep

### DIFF
--- a/native/Arr.pangaea
+++ b/native/Arr.pangaea
@@ -5,6 +5,8 @@
   asFor?: m{|o| .has?(o)},
   # empty? returns whether self contains elements.
   empty?: m{.len.!},
+  # grep filters elements by === match.
+  grep: m{|o| @{\ if \ === o}},
   # rev returns arr with reversed elements.
   rev: m{self[::-1]},
   # unwrap extracts element if there is only one element.

--- a/tests/Arr_grep_test.pangaea
+++ b/tests/Arr_grep_test.pangaea
@@ -1,0 +1,4 @@
+assertEq(['a, 'b, 'c, 'a].grep('a), ['a, 'a])
+# === match
+assertEq(['Pangaea, 'Ruby, 'Golang, 'Python].grep("P"), ['Pangaea, 'Python])
+assertEq((1:6).A.grep({.odd?}), [1, 3, 5])


### PR DESCRIPTION
using `===` check

```
>>> Obj.keys.grep("^a")
["acc", "all?", "ancestors", "any?", "append", "asFor?"]
```