### PR TITLE
Fix nested func call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ pangaea
 # benchmark results
 runscript/cpu.out
 runscript/runscript.test*
+# vscode setting files
+.vscode/*
+__debug_bin

--- a/evaluator/eval_funccall.go
+++ b/evaluator/eval_funccall.go
@@ -38,8 +38,10 @@ func evalPanFuncCall(
 	kwargs *object.PanObj,
 	args ...object.PanObject,
 ) object.PanObject {
-	assignArgsToEnv(f.Env, f.Args().Elems, f.Kwargs(), args, kwargs)
-	retVal := evalStmts(*f.Body(), f.Env)
+	// NOTE: copy is necessary otherwise recurred call breaks outer env! (see TestEvalRecurredFuncCall)
+	e := object.NewCopiedEnv(f.Env)
+	assignArgsToEnv(e, f.Args().Elems, f.Kwargs(), args, kwargs)
+	retVal := evalStmts(*f.Body(), e)
 
 	if err, ok := retVal.(*object.PanErr); ok {
 		return appendStackTrace(err, (*f.Body())[0].Source())

--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -1955,6 +1955,28 @@ func TestEvalMultiLineFuncCall(t *testing.T) {
 	}
 }
 
+func TestEvalRecurredFuncCall(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected object.PanObject
+	}{
+		{
+			`
+			func := {|f| f(); f}
+			inner := {|| 1}
+			outer := {func(inner)}
+			func(outer) == outer
+			`,
+			object.BuiltInTrue,
+		},
+	}
+
+	for _, tt := range tests {
+		actual := testEval(t, tt.input)
+		testValue(t, actual, tt.expected)
+	}
+}
+
 func TestEvalBuiltInFuncCall(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/tests/Arr_doUntil_test.pangaea
+++ b/tests/Arr_doUntil_test.pangaea
@@ -3,3 +3,6 @@ assertEq([2, 4].doUntil {.even?}.A, [2])
 assertEq([].doUntil {.even?}.A, [])
 # doUntil returns iter (not arr)
 assertEq([].doUntil {.even?}.proto, Iter)
+
+# nested call
+assertEq(["abc", "def", "ghi"].doUntil {.doUntil {\ == ?e}.A == [?d, ?e]}.A, ["abc", "def"])

--- a/tests/Arr_doWhile_test.pangaea
+++ b/tests/Arr_doWhile_test.pangaea
@@ -3,3 +3,6 @@ assertEq([2, 4].doWhile {.odd?}.A, [2])
 assertEq([].doWhile {.odd?}.A, [])
 # doWhile returns iter (not arr)
 assertEq([].doWhile {.odd?}.proto, Iter)
+
+# nested call
+assertEq(["abc", "def", "ghi"].doWhile {.doWhile {\ != ?e}.A != [?d, ?e]}.A, ["abc", "def"])

--- a/tests/Arr_find_test.pangaea
+++ b/tests/Arr_find_test.pangaea
@@ -3,3 +3,6 @@ assertEq([1, 2, 3].find {.even?}, 2)
 assertEq([3, 4, 6].find {.even?}, 4)
 # if not found, return nil
 assertEq([1].find {.even?}, nil)
+
+# nested call
+assertEq(["abc", "def", "ghi"].find {.find {\ == ?e}}, "def")

--- a/tests/Arr_until_test.pangaea
+++ b/tests/Arr_until_test.pangaea
@@ -3,3 +3,6 @@ assertEq([2, 4].until {.even?}.A, [])
 assertEq([].until {.even?}.A, [])
 # until returns iter (not arr)
 assertEq([].until {.even?}.proto, Iter)
+
+# nested call
+assertEq(["abc", "def", "ghi"].until {.until {\ == ?e}.A == [?d]}.A, ["abc"])

--- a/tests/Arr_while_test.pangaea
+++ b/tests/Arr_while_test.pangaea
@@ -3,3 +3,6 @@ assertEq([2, 4].while {.odd?}.A, [])
 assertEq([].while {.odd?}.A, [])
 # while returns iter (not arr)
 assertEq([].while {.odd?}.proto, Iter)
+
+# nested call
+assertEq(["abc", "def", "ghi"].while {.while {\ != ?e}.A != [?d]}.A, ["abc"])

--- a/tests/Obj_case_test.pangaea
+++ b/tests/Obj_case_test.pangaea
@@ -19,3 +19,9 @@ assertEq("ABBC".case(%{
   "AB+": 'withAB,
   Obj: 'others,
 }), 'withAB)
+
+assertEq(5.case(%{
+  (7:10): 'great,
+  [4, 5, 6]: 'soso,
+  Int: 'poor,
+}), 'soso)


### PR DESCRIPTION
fix bug that nested func call breaks outer call envs

```
func := {|f| f(); f}
inner := {|| 1}
outer := {func(inner)}
func(outer) == outer # true (before this fix func(outer) returned inner)
```