### PR TITLE
Allow trailing comma

### DIFF
--- a/parser/parser.go.y
+++ b/parser/parser.go.y
@@ -1653,6 +1653,11 @@ callArgs
 		$$ = $2
 		yylex.(*Lexer).curRule = "callArgs -> lParen argList RET RPAREN"
 	}
+	| lParen argList comma RPAREN %prec GROUPING
+	{
+		$$ = $2
+		yylex.(*Lexer).curRule = "callArgs -> lParen argList comma RPAREN"
+	}
 	| lParen kwargExpansionList RPAREN %prec GROUPING
 	{
 		expansionList := []ast.Expr{}

--- a/parser/y_test.go
+++ b/parser/y_test.go
@@ -1713,6 +1713,101 @@ func TestCallArgBreakLines(t *testing.T) {
 			[]int{1, 3},
 			map[string]int{"b": 2},
 		},
+		// trailing comma
+		{
+			`a.b(
+				1,
+				b: 2,
+				3,
+			)`,
+			[]int{1, 3},
+			map[string]int{"b": 2},
+		},
+	}
+
+	for _, tt := range tests {
+		program := testParse(t, tt.input)
+		expr := extractExprStmt(t, program)
+
+		f, ok := expr.(*ast.PropCallExpr)
+		if !ok {
+			t.Fatalf("f is not *ast.PropCallExpr. got=%T", expr)
+		}
+
+		if len(f.Args) != len(tt.args) {
+			t.Fatalf("arity of args is not %d. got=%d",
+				len(tt.args), len(f.Args))
+		}
+
+		if len(f.Kwargs) != len(tt.kwargs) {
+			t.Fatalf("arity of kwargs is not %d. got=%d",
+				len(tt.kwargs), len(f.Kwargs))
+		}
+
+		for i, expArg := range tt.args {
+			testLiteralExpr(t, f.Args[i], expArg)
+		}
+
+		for ident, val := range f.Kwargs {
+			name := ident.Token
+			exp, ok := tt.kwargs[name]
+			if ok {
+				testLiteralExpr(t, val, exp)
+			} else {
+				t.Errorf("unexpected kwarg %s found.", name)
+			}
+		}
+	}
+}
+
+func TestFuncCallArgBreakLines(t *testing.T) {
+	tests := []struct {
+		input  string
+		args   []int
+		kwargs map[string]int
+	}{
+		{
+			`f(1, b: 2, 3)`,
+			[]int{1, 3},
+			map[string]int{"b": 2},
+		},
+		{
+			`f(
+			  1, b: 2, 3)`,
+			[]int{1, 3},
+			map[string]int{"b": 2},
+		},
+		{
+			`f(1,
+				b: 2, 3)`,
+			[]int{1, 3},
+			map[string]int{"b": 2},
+		},
+		{
+			`f(1, b: 2,
+				3)`,
+			[]int{1, 3},
+			map[string]int{"b": 2},
+		},
+		{
+			`f(
+				1,
+				b: 2,
+				3
+			)`,
+			[]int{1, 3},
+			map[string]int{"b": 2},
+		},
+		// trailing comma
+		{
+			`f(
+				1,
+				b: 2,
+				3,
+			)`,
+			[]int{1, 3},
+			map[string]int{"b": 2},
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/Obj_acc_test.pangaea
+++ b/tests/Obj_acc_test.pangaea
@@ -1,14 +1,14 @@
 assertEq(
   {a: 1, b: 2, c: 3}.acc {|acc, i| [acc[0] + i[0], acc[1] + i[1]]}.A,
-  [["a", 1], ["ab", 3], ["abc", 6]]
+  [["a", 1], ["ab", 3], ["abc", 6]],
 )
 assertEq(
   {}.acc {|acc, i| acc + i}.A,
-  []
+  [],
 )
 assertEq(
   {b: 2, c: 3}.acc(init: ['a, 1]) {|acc, i| [acc[0] + i[0], acc[1] + i[1]]}.A,
-  [["ab", 3], ["abc", 6]]
+  [["ab", 3], ["abc", 6]],
 )
 # acc returns iter (not arr)
 assertEq({}.acc {|acc, i| acc + i}.proto, Iter)


### PR DESCRIPTION
fix parser to allow arglist trailing comma

```
Arr(
  1,
  2,
  3, # here!
)

[1, 2, 3]
```