### PR TITLE
evaluator: fix error message of Iter#new with builtInIter

### DIFF
--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -2173,6 +2173,11 @@ func TestEvalIterNew(t *testing.T) {
 				),
 			),
 		},
+		// builtinIter cannot handle new because it cannot hold the received args
+		{
+			`[1, 2, 3]._iter.new(2)`,
+			object.NewValueErr("Iter#new cannot handle builtinIter (use _iter instead)"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/evaluator/iternew.go
+++ b/evaluator/iternew.go
@@ -14,6 +14,10 @@ func iterNew(
 		return object.NewTypeErr("Iter#new requires at least 1 arg")
 	}
 
+	if _, ok := object.TraceProtoOfBuiltInIter(args[0]); ok {
+		return object.NewValueErr("Iter#new cannot handle builtinIter (use _iter instead)")
+	}
+
 	// allow descendant of iter
 	self, ok := object.TraceProtoOfFunc(args[0])
 	if !ok {


### PR DESCRIPTION
```
>>> [1,2,3]._iter.new('a)
ValueErr: Iter#new cannot handle builtinIter (use _iter instead)
```

reason: builtInIter cannot keep received args

If you want to copy builtin iter, just use `._iter`.