### PR TITLE
repr: change const version to var for goreleaser

### DIFF
--- a/runscript/const.go
+++ b/runscript/const.go
@@ -2,7 +2,7 @@ package runscript
 
 // Version represents Pangaea version.
 // NOTE: this version is patched by GoReleaser
-const Version = "master (unstable)"
+var Version = "master (unstable)"
 
 const (
 	// ReadStdinLinesTemplate is a template src for one-liner option


### PR DESCRIPTION
change const `runscript.Version` to var so that goreleaser can patch it by ldflags