### PR TITLE
parser: enable to use escaped double-quotation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+# NOTE: without the settings, any coverage miss fails CI pipeline!
+coverage:
+  status:
+    project:
+      default:
+        target: 80%    # the required coverage value
+        threshold: 1%  # the leniency in hitting the target


### PR DESCRIPTION
```
>>> "\"abc\"".p
"abc"
nil
>>> "1+1\"#{?=}\"2".p
1+1"="2
```