### PR TITLE
Add filpflop

### DIFF
--- a/native/Func.pangaea
+++ b/native/Func.pangaea
@@ -1,4 +1,4 @@
 {
   # asFor? returns whether predicate self is true as for o.
-  asFor?: m{|o| self(o).B},
+  asFor?: m{|o| o.^self.B},
 }

--- a/native/Iterable.pangaea
+++ b/native/Iterable.pangaea
@@ -30,6 +30,15 @@
   empty?: m{.A.empty?},
   # exclude selects elements for which f returns false.
   exclude: m{|f| @{\ if .proto == Arr else [\]}@{\.unwrap if !f(*\)}},
+  # flipflop selects elements from start to end.
+  flipflop: m{|start, end|
+    ._iter$({res: [], started: false}){|acc, i|
+      .started.case(%{
+        true: {res: .res+[i], started: i !== end},
+        false: {res: .res+[i], started: true} if i === start else acc,
+      })
+    }.res
+  },
   # find returns the first element which cond? is true. (returns nil if not found)
   find: m{|cond?| ._iter.doUntil(cond?).last.{\ if &.^cond?}},
   # lazyMap works similar to map but returns iter of elements instead.

--- a/tests/Arr_flipflop_test.pangaea
+++ b/tests/Arr_flipflop_test.pangaea
@@ -1,0 +1,19 @@
+assertEq(
+  ['a, 'start, 'b, 'c, 'end, 'd].flipflop('start, 'end),
+  ['start, 'b, 'c, 'end],
+)
+# not found
+assertEq(
+  ['a].flipflop('start, 'end),
+  [],
+)
+# multiple
+assertEq(
+  ['start, 'a, 'end, 'b, 'start, 'c, 'end, 'd].flipflop('start, 'end),
+  ['start, 'a, 'end, 'start, 'c, 'end],
+)
+# only start found
+assertEq(
+  ['a, 'start, 'b].flipflop('start, 'end),
+  ['start, 'b],
+)

--- a/tests/Func_asForp_test.pangaea
+++ b/tests/Func_asForp_test.pangaea
@@ -1,2 +1,5 @@
 assertEq({|x| x.even?}.asFor?(2), true)
 assertEq({|x| x.even?}.asFor?(3), false)
+# unpack arr (nesessary for key-value === check!)
+assertEq({|k, v| v == 1}.asFor?(["foo", 1]), true)
+assertEq({|k, v| v == 1}.asFor?(["foo", 2]), false)

--- a/tests/Int_flipflop_test.pangaea
+++ b/tests/Int_flipflop_test.pangaea
@@ -1,0 +1,19 @@
+assertEq(
+  10.flipflop(3, 6),
+  [3, 4, 5, 6],
+)
+# not found
+assertEq(
+  1.flipflop(3, 6),
+  [],
+)
+# multiple
+assertEq(
+  8.flipflop({\ % 4 == 1}, {\ % 4 == 3}),
+  [1, 2, 3, 5, 6, 7],
+)
+# only start found
+assertEq(
+  8.flipflop({\ > 6}, {\ < 10}),
+  [7, 8],
+)

--- a/tests/Iter_flipflop_test.pangaea
+++ b/tests/Iter_flipflop_test.pangaea
@@ -1,0 +1,19 @@
+assertEq(
+  <{yield \ if \ < 10; recur(\ + 1)}>.new(1).flipflop(3, 6),
+  [3, 4, 5, 6],
+)
+# not found
+assertEq(
+  <{yield \ if \ < 2; recur(\ + 1)}>.new(1).flipflop(3, 6),
+  [],
+)
+# multiple
+assertEq(
+  <{yield \ if \ < 9; recur(\ + 1)}>.new(1).flipflop({\ % 4 == 1}, {\ % 4 == 3}),
+  [1, 2, 3, 5, 6, 7],
+)
+# only start found
+assertEq(
+  <{yield \ if \ < 9; recur(\ + 1)}>.new(1).flipflop({\ > 6}, {\ < 10}),
+  [7, 8],
+)

--- a/tests/Map_flipflop_test.pangaea
+++ b/tests/Map_flipflop_test.pangaea
@@ -1,0 +1,19 @@
+assertEq(
+  %{'a: 1, 'b: 2, 'c: 3, 'd: 4}.flipflop({|k, v| v > 1}, {|k, v| v > 3}),
+  [['b, 2], ['c, 3], ['d, 4]],
+)
+# not found
+assertEq(
+  %{'a: 1}.flipflop({|k, v| v > 1}, {|k, v| v < 4}),
+  [],
+)
+# multiple
+assertEq(
+  %{'a: 1, 'b: 2, 'c: 3, 'd: 4, 'e: 5, 'f: 6}.flipflop({|k, v| v % 3 == 1}, {|k, v| v % 3 == 2}),
+  [['a, 1], ['b, 2], ['d, 4], ['e, 5]],
+)
+# only start found
+assertEq(
+  %{'a: 1, 'b: 2, 'c: 3, 'd: 4}.flipflop({|k, v| v > 1}, {|k, v| v > 6}),
+  [['b, 2], ['c, 3], ['d, 4]],
+)

--- a/tests/Obj_flipflop_test.pangaea
+++ b/tests/Obj_flipflop_test.pangaea
@@ -1,0 +1,19 @@
+assertEq(
+  {a: 1, b: 2, c: 3, d: 4}.flipflop({|k, v| v > 1}, {|k, v| v > 3}),
+  [['b, 2], ['c, 3], ['d, 4]],
+)
+# not found
+assertEq(
+  {a: 1}.flipflop({|k, v| v > 1}, {|k, v| v < 4}),
+  [],
+)
+# multiple
+assertEq(
+  {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6}.flipflop({|k, v| v % 3 == 1}, {|k, v| v % 3 == 2}),
+  [['a, 1], ['b, 2], ['d, 4], ['e, 5]],
+)
+# only start found
+assertEq(
+  {a: 1, b: 2, c: 3, d: 4}.flipflop({|k, v| v > 1}, {|k, v| v > 6}),
+  [['b, 2], ['c, 3], ['d, 4]],
+)

--- a/tests/Range_flipflop_test.pangaea
+++ b/tests/Range_flipflop_test.pangaea
@@ -1,0 +1,19 @@
+assertEq(
+  (1:10).flipflop(3, 6),
+  [3, 4, 5, 6],
+)
+# not found
+assertEq(
+  (1:2).flipflop(3, 6),
+  [],
+)
+# multiple
+assertEq(
+  (1:9).flipflop({\ % 4 == 1}, {\ % 4 == 3}),
+  [1, 2, 3, 5, 6, 7],
+)
+# only start found
+assertEq(
+  (1:9).flipflop({\ > 6}, {\ < 10}),
+  [7, 8],
+)

--- a/tests/Str_flipflop_test.pangaea
+++ b/tests/Str_flipflop_test.pangaea
@@ -1,0 +1,19 @@
+assertEq(
+  "abcdef".flipflop(?c, ?e),
+  [?c, ?d, ?e],
+)
+# not found
+assertEq(
+  "a".flipflop(?b, ?c),
+  [],
+)
+# multiple
+assertEq(
+  "!ab?cd!ef?g".flipflop(?!, ??),
+  [?!, ?a, ?b, ??, ?!, ?e, ?f, ??],
+)
+# only start found
+assertEq(
+  "!ab?cd!e".flipflop("\\!", "\\?"),
+  [?!, ?a, ?b, ??, ?!, ?e],
+)


### PR DESCRIPTION
```
>>> ["a", "b", "start", "c", "d", "end", "e"].flipflop("start", "end")
["start", "c", "d", "end"]
```