### PR TITLE
Lex faster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,6 @@ require (
 	github.com/tanaton/dtoa v0.0.0-20190918101016-f12936c87cdb
 	golang.org/x/tools v0.1.0
 )
+
+// bundle to patch lexer
+replace github.com/macrat/simplexer v0.0.0-20180110131648-bce8e0661570 => ./third_party/simplexer

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
-github.com/macrat/simplexer v0.0.0-20180110131648-bce8e0661570 h1:ZogDj+/SZbTjeGudnc7KoKoO+6pPZv9bAnCFEH/jxj4=
-github.com/macrat/simplexer v0.0.0-20180110131648-bce8e0661570/go.mod h1:gwtd/9Q5IYQ2OLI6sPHL3wpOS03d8F2bd5jcbdnFMBw=
 github.com/tanaton/dtoa v0.0.0-20190918101016-f12936c87cdb h1:il95NPTEHqAkHbZfBCzEKJdwJJ4xwdpk/s0IsZWYr/4=
 github.com/tanaton/dtoa v0.0.0-20190918101016-f12936c87cdb/go.mod h1:NJ73Q9luv5I1cYrIYSfGC7+oHggSb4YpjpaPGDTHmxI=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/third_party/simplexer/.travis.yml
+++ b/third_party/simplexer/.travis.yml
@@ -1,0 +1,19 @@
+language: go
+
+env:
+  - CC_TEST_REPORTER_ID=c13273b664868621c80b7ebb7cfc13e419b9c38d709d0bf4199b2adb7ec5fc19
+
+before_install:
+  - go get github.com/axw/gocov/gocov
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+
+before_script:
+  - ./cc-test-reporter before-build
+
+script:
+  - go test -coverprofile=cov
+
+after_success:
+  - ./cc-test-reporter format-coverage --input-type gocov cov
+  - ./cc-test-reporter upload-coverage

--- a/third_party/simplexer/LICENSE
+++ b/third_party/simplexer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 MacRat <m@crat.jp>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/simplexer/README.md
+++ b/third_party/simplexer/README.md
@@ -1,0 +1,65 @@
+simplexer
+=========
+
+[![Build Status](https://travis-ci.org/macrat/simplexer.svg?branch=master)](https://travis-ci.org/macrat/simplexer)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/2208d3ac4fbcdcd2b78a/test_coverage)](https://codeclimate.com/github/macrat/simplexer/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/2208d3ac4fbcdcd2b78a/maintainability)](https://codeclimate.com/github/macrat/simplexer/maintainability)
+[![GoDoc](https://godoc.org/github.com/macrat/simplexer?status.svg)](https://godoc.org/github.com/macrat/simplexer)
+
+A simple lexical analyzser for Go.
+
+## example
+### simplest usage
+``` go
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/macrat/simplexer"
+)
+
+func Example() {
+	input := "hello_world = \"hello world\"\nnumber = 1"
+	lexer := simplexer.NewLexer(strings.NewReader(input))
+
+	fmt.Println(input)
+	fmt.Println("==========")
+
+	for {
+		token, err := lexer.Scan()
+		if err != nil {
+			panic(err.Error())
+		}
+		if token == nil {
+			fmt.Println("==========")
+			return
+		}
+
+		fmt.Printf("line %2d, column %2d: %s: %s\n",
+			token.Position.Line,
+			token.Position.Column,
+			token.Type,
+			token.Literal)
+	}
+}
+```
+
+It is output as follow.
+
+``` text
+hello_world = "hello world"
+number = 1
+==========
+line  0, column  0: IDENT: hello_world
+line  0, column 12: OTHER: =
+line  0, column 14: STRING: "hello world"
+line  1, column  0: IDENT: number
+line  1, column  7: OTHER: =
+line  1, column  9: NUMBER: 1
+==========
+```
+
+### more examples
+Please see [godoc](https://godoc.org/github.com/macrat/simplexer).

--- a/third_party/simplexer/doc.go
+++ b/third_party/simplexer/doc.go
@@ -1,0 +1,2 @@
+// A simple lexical analyzer for Go.
+package simplexer

--- a/third_party/simplexer/errors.go
+++ b/third_party/simplexer/errors.go
@@ -1,0 +1,14 @@
+package simplexer
+
+import "fmt"
+
+// The error that returns when found an unknown token.
+type UnknownTokenError struct {
+	Literal  string
+	Position Position
+}
+
+// Get error message as string.
+func (se UnknownTokenError) Error() string {
+	return fmt.Sprintf("%d:%d:UnknownTokenError: %#v", se.Position.Line+1, se.Position.Column+1, se.Literal)
+}

--- a/third_party/simplexer/errors_test.go
+++ b/third_party/simplexer/errors_test.go
@@ -1,0 +1,16 @@
+package simplexer_test
+
+import (
+	"testing"
+
+	"github.com/macrat/simplexer"
+)
+
+func TestUnknownTokenError(t *testing.T) {
+	err := simplexer.UnknownTokenError{Literal: "test", Position: simplexer.Position{Line: 0, Column: 1}}
+	except := "1:2:UnknownTokenError: \"test\""
+
+	if err.Error() != except {
+		t.Errorf("excepted %#v but got %s", except, err.Error())
+	}
+}

--- a/third_party/simplexer/example_test.go
+++ b/third_party/simplexer/example_test.go
@@ -1,0 +1,128 @@
+package simplexer_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/macrat/simplexer"
+)
+
+func Example() {
+	input := "hello_world = \"hello world\"\nnumber = 1"
+	lexer := simplexer.NewLexer(strings.NewReader(input))
+
+	fmt.Println(input)
+	fmt.Println("==========")
+
+	for {
+		token, err := lexer.Scan()
+		if err != nil {
+			panic(err.Error())
+		}
+		if token == nil {
+			fmt.Println("==========")
+			return
+		}
+
+		fmt.Printf("line %2d, column %2d: %s: %s\n",
+			token.Position.Line,
+			token.Position.Column,
+			token.Type,
+			token.Literal)
+	}
+
+	// Output:
+	// hello_world = "hello world"
+	// number = 1
+	// ==========
+	// line  0, column  0: IDENT: hello_world
+	// line  0, column 12: OTHER: =
+	// line  0, column 14: STRING: "hello world"
+	// line  1, column  0: IDENT: number
+	// line  1, column  7: OTHER: =
+	// line  1, column  9: NUMBER: 1
+	// ==========
+}
+
+func Example_positionInformation() {
+	input := "this is a\ntest string\n"
+	lexer := simplexer.NewLexer(strings.NewReader(input))
+
+	for {
+		token, err := lexer.Scan()
+		if err != nil {
+			panic(err.Error())
+		}
+		if token == nil {
+			break
+		}
+
+		fmt.Printf("%d: %s\n", token.Position.Line, lexer.GetLastLine())
+		fmt.Printf(" | %s%s\n\n",
+			strings.Repeat(" ", token.Position.Column),
+			strings.Repeat("=", len(token.Literal)))
+	}
+
+	// Output:
+	// 0: this is a
+	//  | ====
+	//
+	// 0: this is a
+	//  |      ==
+	//
+	// 0: this is a
+	//  |         =
+	//
+	// 1: test string
+	//  | ====
+	//
+	// 1: test string
+	//  |      ======
+}
+
+func Example_addOriginalTokenType() {
+	const (
+		SUBSITUATION simplexer.TokenID = iota
+		NEWLINE
+	)
+
+	input := "hello_world = \"hello world\"\nnumber = 1"
+	lexer := simplexer.NewLexer(strings.NewReader(input))
+
+	lexer.Whitespace = simplexer.NewPatternTokenType(-1, []string{"\t", " "})
+	// lexer.Whitespace = simplexer.NewRegexpTokenType(-1, `[\t ]`)  // same mean above
+
+	lexer.TokenTypes = append([]simplexer.TokenType{
+		simplexer.NewPatternTokenType(SUBSITUATION, []string{"="}),
+		simplexer.NewRegexpTokenType(NEWLINE, `^[\n\r]+`),
+	}, lexer.TokenTypes...)
+
+	fmt.Println(input)
+	fmt.Println("==========")
+
+	for {
+		token, err := lexer.Scan()
+		if err != nil {
+			panic(err.Error())
+		}
+		if token == nil {
+			fmt.Println("==========")
+			return
+		}
+
+		fmt.Printf("%s: %#v\n", token.Type, token.Literal)
+	}
+
+	// Output:
+	// hello_world = "hello world"
+	// number = 1
+	// ==========
+	// IDENT: "hello_world"
+	// UNKNOWN(0): "="
+	// STRING: "\"hello world\""
+	// UNKNOWN(1): "\n"
+	// IDENT: "number"
+	// UNKNOWN(0): "="
+	// NUMBER: "1"
+	// ==========
+}

--- a/third_party/simplexer/go.mod
+++ b/third_party/simplexer/go.mod
@@ -1,0 +1,6 @@
+// created by Syuparn, MIT License
+// (this file is used only for module replacement)
+
+module github.com/macrat/simplexer
+
+go 1.16

--- a/third_party/simplexer/lexer.go
+++ b/third_party/simplexer/lexer.go
@@ -1,3 +1,6 @@
+// this source code is created originally by MacRat (MIT License)
+// and modified by Syuparn (MIT License)
+
 package simplexer
 
 import (
@@ -55,8 +58,16 @@ func (l *Lexer) readBufIfNeed() {
 	if len(l.buf) < 1024 {
 		buf := make([]byte, 2048)
 		l.reader.Read(buf)
-		l.buf += strings.TrimRight(string(buf), "\x00")
+		l.buf += l.trimRightNullStrings(string(buf))
 	}
+}
+
+func (l *Lexer) trimRightNullStrings(s string) string {
+	if i := strings.Index(s, "\x00"); i >= 0 {
+		return s[:i]
+	}
+	// if no null strings found, return s itself
+	return s
 }
 
 func (l *Lexer) consumeBuffer(t *Token) {

--- a/third_party/simplexer/lexer.go
+++ b/third_party/simplexer/lexer.go
@@ -1,0 +1,165 @@
+package simplexer
+
+import (
+	"io"
+	"strings"
+)
+
+// Defined default values for properties of Lexer as a package value.
+var (
+	DefaultWhitespace = NewPatternTokenType(-1, []string{" ", "\t", "\r", "\n"})
+
+	DefaultTokenTypes = []TokenType{
+		NewRegexpTokenType(IDENT, `[a-zA-Z_][a-zA-Z0-9_]*`),
+		NewRegexpTokenType(NUMBER, `[0-9]+(?:\.[0-9]+)?`),
+		NewRegexpTokenType(STRING, `\"([^"]*)\"`),
+		NewRegexpTokenType(OTHER, `.`),
+	}
+)
+
+/*
+The lexical analyzer.
+
+Whitespace is a TokenType for skipping characters like whitespaces.
+The default value is simplexer.DefaultWhitespace.
+Won't skip any characters if Whitespace is nil.
+
+TokenTypes is an array of TokenType.
+Lexer will sequential check TokenTypes, and return first matched token.
+Default is simplexer.DefaultTokenTypes.
+
+Please be careful, Lexer will never use it even if append TokenType after OTHER.
+Because OTHER will accept any single character.
+*/
+type Lexer struct {
+	reader     io.Reader
+	buf        string
+	loadedLine string
+	nextPos    Position
+	Whitespace TokenType
+	TokenTypes []TokenType
+}
+
+// Make a new Lexer.
+func NewLexer(reader io.Reader) *Lexer {
+	l := new(Lexer)
+	l.reader = reader
+
+	l.Whitespace = DefaultWhitespace
+	l.TokenTypes = DefaultTokenTypes
+
+	return l
+}
+
+func (l *Lexer) readBufIfNeed() {
+	if len(l.buf) < 1024 {
+		buf := make([]byte, 2048)
+		l.reader.Read(buf)
+		l.buf += strings.TrimRight(string(buf), "\x00")
+	}
+}
+
+func (l *Lexer) consumeBuffer(t *Token) {
+	if t == nil {
+		return
+	}
+
+	l.buf = l.buf[len(t.Literal):]
+
+	l.nextPos = shiftPos(l.nextPos, t.Literal)
+
+	if idx := strings.LastIndex(t.Literal, "\n"); idx >= 0 {
+		l.loadedLine = t.Literal[idx+1:]
+	} else {
+		l.loadedLine += t.Literal
+	}
+}
+
+func (l *Lexer) skipWhitespace() {
+	if l.Whitespace == nil {
+		return
+	}
+
+	for true {
+		l.readBufIfNeed()
+
+		if t := l.Whitespace.FindToken(l.buf, l.nextPos); t != nil {
+			l.consumeBuffer(t)
+		} else {
+			break
+		}
+	}
+}
+
+func (l *Lexer) makeError() error {
+	for shift, _ := range l.buf {
+		if l.Whitespace != nil && l.Whitespace.FindToken(l.buf[shift:], l.nextPos) != nil {
+			return UnknownTokenError{
+				Literal:  l.buf[:shift],
+				Position: l.nextPos,
+			}
+		}
+
+		for _, tokenType := range l.TokenTypes {
+			if tokenType.FindToken(l.buf[shift:], l.nextPos) != nil {
+				return UnknownTokenError{
+					Literal:  l.buf[:shift],
+					Position: l.nextPos,
+				}
+			}
+		}
+	}
+
+	return UnknownTokenError{
+		Literal:  l.buf,
+		Position: l.nextPos,
+	}
+}
+
+/*
+Peek the first token in the buffer.
+
+Returns nil as *Token if the buffer is empty.
+*/
+func (l *Lexer) Peek() (*Token, error) {
+	for _, tokenType := range l.TokenTypes {
+		l.skipWhitespace()
+
+		l.readBufIfNeed()
+		if t := tokenType.FindToken(l.buf, l.nextPos); t != nil {
+			return t, nil
+		}
+	}
+
+	if len(l.buf) > 0 {
+		return nil, l.makeError()
+	}
+
+	return nil, nil
+}
+
+/*
+Scan will get the first token in the buffer and remove it from the buffer.
+
+This function using Lexer.Peek. Please read document of Peek.
+*/
+func (l *Lexer) Scan() (*Token, error) {
+	t, e := l.Peek()
+
+	l.consumeBuffer(t)
+
+	return t, e
+}
+
+/*
+GetCurrentLine returns line of last scanned token.
+*/
+func (l *Lexer) GetLastLine() string {
+	l.readBufIfNeed()
+
+	if idx := strings.Index(l.buf, "\n"); idx >= 0 {
+		return l.loadedLine + l.buf[:strings.Index(l.buf, "\n")]
+	} else {
+		return l.loadedLine + l.buf
+	}
+}

--- a/third_party/simplexer/lexer_test.go
+++ b/third_party/simplexer/lexer_test.go
@@ -1,0 +1,290 @@
+package simplexer_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/macrat/simplexer"
+)
+
+type want struct {
+	TypeID   simplexer.TokenID
+	Literal  string
+	Pos      simplexer.Position
+	LastLine string
+}
+
+func execute(t *testing.T, input string, wants []want) {
+	lexer := simplexer.NewLexer(strings.NewReader(input))
+
+	for _, except := range wants {
+		token, err := lexer.Scan()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if token == nil {
+			t.Fatalf("excepted token type=%s literal=%#v but got nil", except.TypeID, except.Literal)
+		}
+
+		if token.Type.GetID() != except.TypeID {
+			t.Errorf("excepted type %s but got %s", except.TypeID, token.Type.GetID())
+		}
+		if token.Literal != except.Literal {
+			t.Errorf("excepted literal %#v but got %#v", except.Literal, token.Literal)
+		}
+
+		if token.Position != except.Pos {
+			t.Errorf("excepted position %#v but got %#v", except.Pos, token.Position)
+		}
+
+		if lexer.GetLastLine() != except.LastLine {
+			t.Errorf("excepted last line %#v but got %#v", except.LastLine, lexer.GetLastLine())
+		}
+	}
+
+	token, err := lexer.Scan()
+	if token != nil {
+		t.Errorf("excepted end but got %#v", token)
+	}
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+func TestLexer(t *testing.T) {
+	execute(t, "\t10; literal\nhoge = \"abc\"", []want{
+		{
+			TypeID:   simplexer.NUMBER,
+			Literal:  "10",
+			Pos:      simplexer.Position{Line: 0, Column: 1},
+			LastLine: "\t10; literal",
+		},
+		{
+			TypeID:   simplexer.OTHER,
+			Literal:  ";",
+			Pos:      simplexer.Position{Line: 0, Column: 3},
+			LastLine: "\t10; literal",
+		},
+		{
+			TypeID:   simplexer.IDENT,
+			Literal:  "literal",
+			Pos:      simplexer.Position{Line: 0, Column: 5},
+			LastLine: "\t10; literal",
+		},
+		{
+			TypeID:   simplexer.IDENT,
+			Literal:  "hoge",
+			Pos:      simplexer.Position{Line: 1, Column: 0},
+			LastLine: "hoge = \"abc\"",
+		},
+		{
+			TypeID:   simplexer.OTHER,
+			Literal:  "=",
+			Pos:      simplexer.Position{Line: 1, Column: 5},
+			LastLine: "hoge = \"abc\"",
+		},
+		{
+			TypeID:   simplexer.STRING,
+			Literal:  "\"abc\"",
+			Pos:      simplexer.Position{Line: 1, Column: 7},
+			LastLine: "hoge = \"abc\"",
+		},
+	})
+}
+
+func TestLexer_oneLine(t *testing.T) {
+	execute(t, "this is \"one line\"", []want{
+		{
+			TypeID:   simplexer.IDENT,
+			Literal:  "this",
+			Pos:      simplexer.Position{Line: 0, Column: 0},
+			LastLine: "this is \"one line\"",
+		},
+		{
+			TypeID:   simplexer.IDENT,
+			Literal:  "is",
+			Pos:      simplexer.Position{Line: 0, Column: 5},
+			LastLine: "this is \"one line\"",
+		},
+		{
+			TypeID:   simplexer.STRING,
+			Literal:  "\"one line\"",
+			Pos:      simplexer.Position{Line: 0, Column: 8},
+			LastLine: "this is \"one line\"",
+		},
+	})
+}
+
+func TestLexer_reportingError(t *testing.T) {
+	lexer := simplexer.NewLexer(strings.NewReader("1 2 error 3 4"))
+	lexer.TokenTypes = []simplexer.TokenType{
+		simplexer.NewRegexpTokenType(0, `^[0-9]+`),
+	}
+
+	if token, err := lexer.Scan(); err != nil {
+		t.Fatalf("%s", err.Error())
+	} else if token.Literal != "1" {
+		t.Fatalf("except 1 but got %s", token.Literal)
+	}
+
+	if token, err := lexer.Scan(); err != nil {
+		t.Fatalf("%s", err.Error())
+	} else if token.Literal != "2" {
+		t.Fatalf("except 2 but got %s", token.Literal)
+	}
+
+	token, e := lexer.Scan()
+	if e == nil {
+		t.Fatalf("except error but got nil")
+	}
+	if token != nil {
+		t.Errorf("token when error except nil but got %s", token)
+	}
+
+	err, ok := e.(simplexer.UnknownTokenError)
+	if !ok {
+		t.Fatalf("except UnknownTokenError but got other error")
+	}
+
+	exceptPos := simplexer.Position{Line: 0, Column: 4}
+	if err.Position != exceptPos {
+		t.Errorf("position of error excepts %v but got %v", exceptPos, err.Position)
+	}
+
+	exceptLiteral := "error"
+	if err.Literal != exceptLiteral {
+		t.Errorf("literal of error excepts %s but got %s", exceptLiteral, err.Literal)
+	}
+}
+
+func TestLexer_reportingError_withoutSpace(t *testing.T) {
+	lexer := simplexer.NewLexer(strings.NewReader("1 2 error3 4"))
+	lexer.TokenTypes = []simplexer.TokenType{
+		simplexer.NewRegexpTokenType(0, `^[0-9]+`),
+	}
+
+	if token, err := lexer.Scan(); err != nil {
+		t.Fatalf("%s", err.Error())
+	} else if token.Literal != "1" {
+		t.Fatalf("except 1 but got %s", token.Literal)
+	}
+
+	if token, err := lexer.Scan(); err != nil {
+		t.Fatalf("%s", err.Error())
+	} else if token.Literal != "2" {
+		t.Fatalf("except 2 but got %s", token.Literal)
+	}
+
+	token, e := lexer.Scan()
+	if e == nil {
+		t.Fatalf("except error but got nil")
+	}
+	if token != nil {
+		t.Errorf("token when error except nil but got %s", token)
+	}
+
+	err, ok := e.(simplexer.UnknownTokenError)
+	if !ok {
+		t.Fatalf("except UnknownTokenError but got other error")
+	}
+
+	exceptPos := simplexer.Position{Line: 0, Column: 4}
+	if err.Position != exceptPos {
+		t.Errorf("position of error excepts %v but got %v", exceptPos, err.Position)
+	}
+
+	exceptLiteral := "error"
+	if err.Literal != exceptLiteral {
+		t.Errorf("literal of error excepts %s but got %s", exceptLiteral, err.Literal)
+	}
+}
+
+func TestLexer_reportingError_atLast(t *testing.T) {
+	lexer := simplexer.NewLexer(strings.NewReader("12error"))
+	lexer.TokenTypes = []simplexer.TokenType{
+		simplexer.NewRegexpTokenType(0, `^[0-9]+`),
+	}
+
+	if token, err := lexer.Scan(); err != nil {
+		t.Fatalf("%s", err.Error())
+	} else if token.Literal != "12" {
+		t.Fatalf("except 12 but got %s", token.Literal)
+	}
+
+	token, e := lexer.Scan()
+	if e == nil {
+		t.Fatalf("except error but got nil")
+	}
+	if token != nil {
+		t.Errorf("token when error except nil but got %s", token)
+	}
+
+	err, ok := e.(simplexer.UnknownTokenError)
+	if !ok {
+		t.Fatalf("except UnknownTokenError but got other error")
+	}
+
+	exceptPos := simplexer.Position{Line: 0, Column: 2}
+	if err.Position != exceptPos {
+		t.Errorf("position of error excepts %v but got %v", exceptPos, err.Position)
+	}
+
+	exceptLiteral := "error"
+	if err.Literal != exceptLiteral {
+		t.Errorf("literal of error excepts %s but got %s", exceptLiteral, err.Literal)
+	}
+}
+
+func TestLexer_Whitespace(t *testing.T) {
+	lexer := simplexer.NewLexer(strings.NewReader("\ta---b c"))
+
+	lexer.Whitespace = simplexer.NewRegexpTokenType(0, `[\s\t\r\n]+`)
+
+	tok, err := lexer.Scan()
+	if err != nil {
+		t.Fatalf("failed scan: %s", err.Error())
+	}
+	if tok == nil {
+		t.Fatalf("failed scan, Lexer returned nil")
+	}
+	if tok.Literal != "a" {
+		t.Errorf("excepted \"a\" but got %#v", tok.Literal)
+	}
+
+	lexer.Whitespace = simplexer.NewPatternTokenType(0, []string{"-"})
+
+	tok, err = lexer.Scan()
+	if err != nil {
+		t.Fatalf("failed scan: %s", err.Error())
+	}
+	if tok == nil {
+		t.Fatalf("failed scan, Lexer returned nil")
+	}
+	if tok.Literal != "b" {
+		t.Errorf("excepted \"b\" but got %#v", tok.Literal)
+	}
+
+	lexer.Whitespace = nil
+
+	tok, err = lexer.Scan()
+	if err != nil {
+		t.Fatalf("failed scan: %s", err.Error())
+	}
+	if tok == nil {
+		t.Fatalf("failed scan, Lexer returned nil")
+	}
+	if tok.Literal != " " {
+		t.Errorf("excepted \" \" but got %#v", tok.Literal)
+	}
+
+	tok, err = lexer.Scan()
+	if err != nil {
+		t.Fatalf("failed scan: %s", err.Error())
+	}
+	if tok == nil {
+		t.Fatalf("failed scan, Lexer returned nil")
+	}
+	if tok.Literal != "c" {
+		t.Errorf("excepted \"c\" but got %#v", tok.Literal)
+	}
+}

--- a/third_party/simplexer/position.go
+++ b/third_party/simplexer/position.go
@@ -1,0 +1,41 @@
+package simplexer
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Position in the file.
+type Position struct {
+	Line   int
+	Column int
+}
+
+// Convert to string.
+func (p Position) String() string {
+	return fmt.Sprintf("[line:%d, column:%d]", p.Line, p.Column)
+}
+
+// Position.Before will check p is before than x.
+func (p Position) Before(x Position) bool {
+	return p.Line < x.Line || (p.Line == x.Line && p.Column < x.Column)
+}
+
+// Position.After will check p is after than x.
+func (p Position) After(x Position) bool {
+	return p.Line > x.Line || (p.Line == x.Line && p.Column > x.Column)
+}
+
+func shiftPos(p Position, s string) Position {
+	lines := strings.Split(s, "\n")
+	lineShift := len(lines) - 1
+
+	if lineShift == 0 {
+		p.Column += len(lines[0])
+	} else {
+		p.Column = len(lines[len(lines)-1])
+	}
+	p.Line += lineShift
+
+	return p
+}

--- a/third_party/simplexer/position_test.go
+++ b/third_party/simplexer/position_test.go
@@ -1,0 +1,52 @@
+package simplexer_test
+
+import (
+	"testing"
+
+	"github.com/macrat/simplexer"
+)
+
+func TestPositionString(t *testing.T) {
+	if s := (simplexer.Position{Line: 0, Column: 1}).String(); s != "[line:0, column:1]" {
+		t.Errorf("failed convert to string: excepted [line:0, column:1] but got %#v", s)
+	}
+
+	if s := (simplexer.Position{Line: 5, Column: 3}).String(); s != "[line:5, column:3]" {
+		t.Errorf("failed convert to string: excepted [line:5, column:3] but got %#v", s)
+	}
+}
+
+func TestPositionCompare(t *testing.T) {
+	a := simplexer.Position{Line: 0, Column: 0}
+	a2 := simplexer.Position{Line: 0, Column: 0}
+	b := simplexer.Position{Line: 0, Column: 5}
+	c := simplexer.Position{Line: 1, Column: 3}
+
+	if a != a2 {
+		t.Errorf("Position reports %v != %v", a, a2)
+	}
+
+	if !a.Before(b) {
+		t.Errorf("Position reports %v is not before of %v", a, b)
+	}
+
+	if !a.Before(c) {
+		t.Errorf("Position reports %v is not before of %v", a, c)
+	}
+
+	if !b.Before(c) {
+		t.Errorf("Position reports %v is not before of %v", b, c)
+	}
+
+	if !b.After(a) {
+		t.Errorf("Position reports %v is not after of %v", b, a)
+	}
+
+	if !c.After(a) {
+		t.Errorf("Position reports %v is not after of %v", c, a)
+	}
+
+	if !c.After(b) {
+		t.Errorf("Position reports %v is not after of %v", c, b)
+	}
+}

--- a/third_party/simplexer/token.go
+++ b/third_party/simplexer/token.go
@@ -1,0 +1,161 @@
+package simplexer
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// TokenID is Identifier for TokenType.
+type TokenID int
+
+// Default token IDs.
+const (
+	OTHER TokenID = -(iota + 1)
+	IDENT
+	NUMBER
+	STRING
+)
+
+/*
+Convert to readable string.
+
+Be careful, user added token ID's will convert to UNKNOWN.
+*/
+func (id TokenID) String() string {
+	switch id {
+	case OTHER:
+		return "OTHER"
+	case IDENT:
+		return "IDENT"
+	case NUMBER:
+		return "NUMBER"
+	case STRING:
+		return "STRING"
+	default:
+		return "UNKNOWN(" + strconv.Itoa(int(id)) + ")"
+	}
+}
+
+/*
+TokenType is a rule for making Token.
+
+GetID returns TokenID of this TokenType.
+TokenID can share with another TokenType.
+
+FindToken returns new Token if the head of first argument was matched with the pattern of this TokenType.
+The second argument is a position of the token in the buffer. In almost implement, Position will pass into result Token directly.
+*/
+type TokenType interface {
+	GetID() TokenID
+	FindToken(string, Position) *Token
+}
+
+/*
+RegexpTokenType is a TokenType implement with regexp.
+
+ID is TokenID for this token type.
+
+Re is regular expression of token. It have to starts with "^".
+*/
+type RegexpTokenType struct {
+	ID TokenID
+	Re *regexp.Regexp
+}
+
+/*
+Make new RegexpTokenType.
+
+id is a TokenID of new RegexpTokenType.
+
+re is a regular expression of token.
+*/
+func NewRegexpTokenType(id TokenID, re string) *RegexpTokenType {
+	if !strings.HasPrefix(re, "^") {
+		re = "^(?:" + re + ")"
+	}
+	return &RegexpTokenType{
+		ID: id,
+		Re: regexp.MustCompile(re),
+	}
+}
+
+// Get readable string of TokenID.
+func (rtt *RegexpTokenType) String() string {
+	return rtt.ID.String()
+}
+
+// GetID returns id of this token type.
+func (rtt *RegexpTokenType) GetID() TokenID {
+	return rtt.ID
+}
+
+// FindToken returns new Token if s starts with this token.
+func (rtt *RegexpTokenType) FindToken(s string, p Position) *Token {
+	m := rtt.Re.FindStringSubmatch(s)
+	if len(m) > 0 {
+		return &Token{
+			Type:       rtt,
+			Literal:    m[0],
+			Submatches: m[1:],
+			Position:   p,
+		}
+	}
+	return nil
+}
+
+/*
+PatternTokenType is dictionary token type.
+
+PatternTokenType has some strings and find token that perfect match they.
+*/
+type PatternTokenType struct {
+	ID       TokenID
+	Patterns []string
+}
+
+/*
+Make new PatternTokenType.
+
+id is a TokenID of new PatternTokenType.
+
+patterns is array of patterns.
+*/
+func NewPatternTokenType(id TokenID, patterns []string) *PatternTokenType {
+	return &PatternTokenType{
+		ID:       id,
+		Patterns: patterns,
+	}
+}
+
+// Get readable string of TokenID.
+func (ptt *PatternTokenType) String() string {
+	return ptt.ID.String()
+}
+
+// GetID returns id of token type.
+func (ptt *PatternTokenType) GetID() TokenID {
+	return ptt.ID
+}
+
+// FindToken returns new Token if s starts with this token.
+func (ptt *PatternTokenType) FindToken(s string, p Position) *Token {
+	for _, x := range ptt.Patterns {
+		if strings.HasPrefix(s, x) {
+			return &Token{
+				Type:     ptt,
+				Literal:  x,
+				Position: p,
+			}
+		}
+	}
+	return nil
+}
+
+// A data of found Token.
+type Token struct {
+	Type       TokenType
+	Literal    string   // The string of matched.
+	Submatches []string // Submatches of regular expression.
+	Position   Position // Position of token.
+}

--- a/third_party/simplexer/token_test.go
+++ b/third_party/simplexer/token_test.go
@@ -1,0 +1,161 @@
+package simplexer_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/macrat/simplexer"
+)
+
+func ExampleNewRegexpTokenType() {
+	const (
+		NUMBER simplexer.TokenID = iota
+		OTHERS
+	)
+
+	lexer := simplexer.NewLexer(strings.NewReader("123this is test456"))
+
+	lexer.TokenTypes = []simplexer.TokenType{
+		simplexer.NewRegexpTokenType(NUMBER, `[0-9]+`),
+		simplexer.NewRegexpTokenType(OTHERS, `[^0-9]+`),
+	}
+
+	for {
+		token, _ := lexer.Scan()
+		if token == nil {
+			break
+		}
+
+		if token.Type.GetID() == NUMBER {
+			fmt.Printf("%s is number\n", token.Literal)
+		}
+
+		if token.Type.GetID() == OTHERS {
+			fmt.Printf("%s is not number\n", token.Literal)
+		}
+	}
+
+	// Output:
+	// 123 is number
+	// this is test is not number
+	// 456 is number
+}
+
+func ExampleNewPatternTokenType() {
+	const (
+		HOGE simplexer.TokenID = iota
+		OTHERS
+	)
+
+	lexer := simplexer.NewLexer(strings.NewReader("this is hoge and HOGE or Hoge"))
+
+	lexer.TokenTypes = []simplexer.TokenType{
+		simplexer.NewPatternTokenType(HOGE, []string{"hoge", "HOGE"}),
+		simplexer.NewRegexpTokenType(OTHERS, `[^ ]+`),
+	}
+
+	for {
+		token, _ := lexer.Scan()
+		if token == nil {
+			break
+		}
+
+		if token.Type.GetID() == HOGE {
+			fmt.Printf("!!! %s !!!\n", token.Literal)
+		}
+
+		if token.Type.GetID() == OTHERS {
+			fmt.Println(token.Literal)
+		}
+	}
+
+	// Output:
+	// this
+	// is
+	// !!! hoge !!!
+	// and
+	// !!! HOGE !!!
+	// or
+	// Hoge
+}
+
+func TestRegexpTokenType(t *testing.T) {
+	tt := simplexer.NewRegexpTokenType(1, `[0-9]+(\.[0-9]+)?`)
+
+	if tok := tt.FindToken("not match 123", simplexer.Position{}); tok != nil {
+		t.Errorf("excepted nil but got %#v", tok)
+	}
+
+	pos := simplexer.Position{Line: 1, Column: 2}
+
+	if tok := tt.FindToken("123.1abc", pos); tok == nil {
+		t.Errorf("excepted token but got nil")
+	} else {
+		if tok.Type != tt {
+			t.Errorf("excepted token type is %#v but got %#v", &tt, &tok.Type)
+		}
+		if tok.Type.GetID() != 1 {
+			t.Errorf("excepted token type ID is 1 but got %#v", tok.Type.GetID())
+		}
+		if tok.Literal != "123.1" {
+			t.Errorf("excepted literal of token is 123.1 but got %#v", tok.Literal)
+		}
+		if len(tok.Submatches) != 1 || tok.Submatches[0] != ".1" {
+			t.Errorf("excepted submatches of token is %#v but got %#v", []string{".1"}, tok.Submatches)
+		}
+		if tok.Position != pos {
+			t.Errorf("excepted position of token is %#v but got %#v", pos, tok.Position)
+		}
+	}
+}
+
+func TestPatternTokenType(t *testing.T) {
+	tt := simplexer.NewPatternTokenType(1, []string{"abc", "def"})
+
+	if tok := tt.FindToken("not match abc", simplexer.Position{}); tok != nil {
+		t.Errorf("excepted nil but got %#v", tok)
+	}
+
+	pos := simplexer.Position{Line: 1, Column: 2}
+
+	if tok := tt.FindToken("abc def", pos); tok == nil {
+		t.Errorf("excepted token but got nil")
+	} else {
+		if tok.Type != tt {
+			t.Errorf("excepted token type is %#v but got %#v", &tt, &tok.Type)
+		}
+		if tok.Type.GetID() != 1 {
+			t.Errorf("excepted token type ID is 1 but got %#v", tok.Type.GetID())
+		}
+		if tok.Literal != "abc" {
+			t.Errorf("excepted literal of token is abc but got %#v", tok.Literal)
+		}
+		if len(tok.Submatches) != 0 {
+			t.Errorf("excepted submatches of token is empty but got %#v", tok.Submatches)
+		}
+		if tok.Position != pos {
+			t.Errorf("excepted position of token is %#v but got %#v", pos, tok.Position)
+		}
+	}
+
+	if tok := tt.FindToken("def", pos); tok == nil {
+		t.Errorf("excepted token but got nil")
+	} else {
+		if tok.Type != tt {
+			t.Errorf("excepted token type is %#v but got %#v", &tt, &tok.Type)
+		}
+		if tok.Type.GetID() != 1 {
+			t.Errorf("excepted token type ID is 1 but got %#v", tok.Type.GetID())
+		}
+		if tok.Literal != "def" {
+			t.Errorf("excepted literal of token is def but got %#v", tok.Literal)
+		}
+		if len(tok.Submatches) != 0 {
+			t.Errorf("excepted submatches of token is empty but got %#v", tok.Submatches)
+		}
+		if tok.Position != pos {
+			t.Errorf("excepted position of token is %#v but got %#v", pos, tok.Position)
+		}
+	}
+}


### PR DESCRIPTION
## about

patch `simplexer.Lexer#readBufIfNeed` to lex faster

## benchmark

- use `runscript.BenckmarkSetup` https://github.com/Syuparn/Pangaea/blob/master/runscript/run_test.go#L8
  - lex, parse, and evaluate all built-in native properties
- machine
  - OS: Windows 10
  - CPU: Intel Corei7-7500U 2CPUs/4 Processes
  - Memory: 8GB

```bash
# in ./runscript
$ go test -bench=. -cpuprofile hoge.prof
$ go tool pprof -http :6060 hoge.prof
```

### before

- total: 2.70s
  - readBufIfNeed: 1.96s (72.59%)

<img width="953" alt="benchmark_before" src="https://user-images.githubusercontent.com/36665200/129646166-40b8ac5c-d46b-4141-ad8d-43c8cfc63386.png">

### after

- total: 0.40s
  - readBufIfNeed: 0.14s (35.00%)

<img width="954" alt="benchmark_after" src="https://user-images.githubusercontent.com/36665200/129646178-2641a7f4-72cc-4143-b057-224e075944af.png">

