### PR TITLE
evaluator: fix jumpifstmt return wrapping

### DIFF
--- a/evaluator/eval_jumpifstmt.go
+++ b/evaluator/eval_jumpifstmt.go
@@ -61,7 +61,7 @@ func evalJumpIfReturn(
 	if err, ok := ret.(*object.PanErr); ok {
 		return appendStackTrace(err, node.Source())
 	}
-	return &object.ReturnObj{PanObject: ret}
+	return ret
 }
 
 func evalJumpIfDefer(
@@ -111,5 +111,5 @@ func evalJumpIfRaise(
 		return appendStackTrace(&err, node.Source())
 	}
 
-	return &object.ReturnObj{PanObject: ret}
+	return ret
 }

--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -2681,6 +2681,15 @@ func TestEvalJumpIfStmt(t *testing.T) {
 			`{|i| raise Err.new("new error") if false; i}(2)`,
 			object.NewPanInt(2),
 		},
+		// recursion
+		{
+			`fact := {|n| return 1 if n == 0; n * fact(n - 1)}; fact(4)`,
+			object.NewPanInt(24),
+		},
+		{
+			`fact := {|n| raise 1 if n == 0; n * fact(n - 1)}; fact(4)`,
+			object.NewPanInt(24),
+		},
 	}
 	for _, tt := range tests {
 		actual := testEval(t, tt.input)


### PR DESCRIPTION
fix recursion call with `return if`

before:

```
>>> fact := {|n| return 1 if n == 0 ; n * fact(n - 1)}
{|n|
return 1 if (n == 0)
(n * fact.call((n - 1)))
}
>>> fact(4)
0
```

after:

```
>>> fact := {|n| return 1 if n == 0 ; n * fact(n - 1)}
{|n|
return 1 if (n == 0)
(n * fact.call((n - 1)))
}
>>> fact(4)
24
```