### PR TITLE
Inherit arr new

### DIFF
--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -7300,61 +7300,92 @@ func TestEvalInfixStrEq(t *testing.T) {
 
 func TestEvalInfixArrEq(t *testing.T) {
 	tests := []struct {
+		title    string
 		input    string
 		expected object.PanObject
 	}{
 		// true if all elements are equivalent
 		{
+			"empty arr is empty arr",
 			`[] == []`,
 			object.BuiltInTrue,
 		},
 		{
+			"all eleements are equivalent",
 			`[1, "a"] == [1, "a"]`,
 			object.BuiltInTrue,
 		},
 		{
+			"not equal",
 			`[] == 'a`,
 			object.BuiltInFalse,
 		},
 		{
+			"too many elements",
 			`[1, 2] == [1]`,
 			object.BuiltInFalse,
 		},
 		{
+			"too few elements",
 			`[1, 2] == [1, 2, 3]`,
 			object.BuiltInFalse,
 		},
 		{
+			"with different element",
 			`[1, 2] == [1, "2"]`,
 			object.BuiltInFalse,
 		},
 		{
+			"nested comparison",
 			`[1, [2, 3]] == [1, [2, 3]]`,
 			object.BuiltInTrue,
 		},
 		{
+			"nested element is different",
 			`[1, [2, 3]] == [1, [2, 4]]`,
 			object.BuiltInFalse,
 		},
-		// ancestors are also comparable
 		{
-			`[2].bear == [2]`,
-			object.BuiltInTrue,
-		},
-		// Arr is treated as []
-		{
+			"Arr is treated as []",
 			`[] == Arr`,
 			object.BuiltInTrue,
 		},
 		{
+			"Arr is Arr",
 			`Arr == Arr`,
 			object.BuiltInTrue,
+		},
+		{
+			"descendant of array is equivalent",
+			`[2].bear == [2]`,
+			object.BuiltInTrue,
+		},
+		{
+			"descendant of Arr is equivalent",
+			`Arr.bear == Arr`,
+			object.BuiltInTrue,
+		},
+		// FIXME: enable to treat Arr descendant as empty arr
+		/*
+			{
+				"Child is treated as zero value Child()",
+				`Arr.bear => Child; Child() == Child`,
+				object.BuiltInTrue,
+			},
+		*/
+		{
+			"not equivalent because Child(1) is NOT [1]'s proto",
+			`Arr.bear => Child; Child(1) == [1]`,
+			object.BuiltInFalse,
 		},
 	}
 
 	for _, tt := range tests {
-		actual := testEval(t, tt.input)
-		testValue(t, actual, tt.expected)
+		tt := tt // pin
+		t.Run(tt.title, func(t *testing.T) {
+			actual := testEval(t, tt.input)
+			testValue(t, actual, tt.expected)
+		})
 	}
 }
 

--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -7304,7 +7304,6 @@ func TestEvalInfixArrEq(t *testing.T) {
 		input    string
 		expected object.PanObject
 	}{
-		// true if all elements are equivalent
 		{
 			"empty arr is empty arr",
 			`[] == []`,
@@ -7361,21 +7360,29 @@ func TestEvalInfixArrEq(t *testing.T) {
 			object.BuiltInTrue,
 		},
 		{
-			"descendant of Arr is equivalent",
+			// Arr's zero value is [] but Arr.bear's zero value is Arr.bear()
+			"descendant of Arr is different",
 			`Arr.bear == Arr`,
+			object.BuiltInFalse,
+		},
+		{
+			"Child is treated as zero value Child()",
+			`Arr.bear => Child; Child() == Child`,
 			object.BuiltInTrue,
 		},
-		// FIXME: enable to treat Arr descendant as empty arr
-		/*
-			{
-				"Child is treated as zero value Child()",
-				`Arr.bear => Child; Child() == Child`,
-				object.BuiltInTrue,
-			},
-		*/
 		{
 			"not equivalent because Child(1) is NOT [1]'s proto",
 			`Arr.bear => Child; Child(1) == [1]`,
+			object.BuiltInFalse,
+		},
+		{
+			"Child is treated as zero value Child.new([])",
+			`Arr.bear => Child; Child.new([]) == Child`,
+			object.BuiltInTrue,
+		},
+		{
+			"not equivalent because Child.new([1]) is NOT [1]'s proto",
+			`Arr.bear => Child; Child.new([1]) == [1]`,
 			object.BuiltInFalse,
 		},
 	}

--- a/native/Arr.pangaea
+++ b/native/Arr.pangaea
@@ -1,6 +1,7 @@
 {
   # A converts self into arr.
-  A: m{self},
+  # NOTE: arr descendant is converted into Arr's child
+  A: m{self[:]},
   # asFor? returns whether predicate self is true as for o.
   asFor?: m{|o| .has?(o)},
   # digest merges arr pairs with self

--- a/object/arr.go
+++ b/object/arr.go
@@ -14,6 +14,7 @@ var zeroArr = NewPanArr()
 // PanArr is object of arr literal.
 type PanArr struct {
 	Elems []PanObject
+	proto PanObject
 }
 
 // Type returns type of this PanObject.
@@ -51,10 +52,21 @@ func (a *PanArr) Repr() string {
 
 // Proto returns proto of this object.
 func (a *PanArr) Proto() PanObject {
-	return BuiltInArrObj
+	return a.proto
 }
 
 // NewPanArr returns new arr object.
 func NewPanArr(elems ...PanObject) *PanArr {
-	return &PanArr{Elems: elems}
+	return &PanArr{
+		Elems: elems,
+		proto: BuiltInArrObj,
+	}
+}
+
+// NewInheritedArr returns new arr object born of proto.
+func NewInheritedArr(proto PanObject, elems ...PanObject) *PanArr {
+	return &PanArr{
+		Elems: elems,
+		proto: proto,
+	}
 }

--- a/object/arr.go
+++ b/object/arr.go
@@ -8,9 +8,6 @@ import (
 // ArrType is a type of PanArr.
 const ArrType = "ArrType"
 
-// used as zero value
-var zeroArr = NewPanArr()
-
 // PanArr is object of arr literal.
 type PanArr struct {
 	Elems []PanObject
@@ -53,6 +50,11 @@ func (a *PanArr) Repr() string {
 // Proto returns proto of this object.
 func (a *PanArr) Proto() PanObject {
 	return a.proto
+}
+
+// Zero returns zero value of this object.
+func (a *PanArr) Zero() PanObject {
+	return a
 }
 
 // NewPanArr returns new arr object.

--- a/object/arr_test.go
+++ b/object/arr_test.go
@@ -121,6 +121,32 @@ func TestInheritedArrProto(t *testing.T) {
 	}
 }
 
+func TestArrZero(t *testing.T) {
+	// Arr.bear
+	arrChild := ChildPanObjPtr(BuiltInArrObj, EmptyPanObjPtr())
+
+	tests := []struct {
+		name string
+		obj  *PanArr
+	}{
+		{"[1]", NewPanArr(NewPanInt(1))},
+		{"Child(1)", NewInheritedArr(arrChild, NewPanInt(1))},
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.obj.Zero()
+
+			if actual != tt.obj {
+				t.Errorf("zero must be itself (%#v). got=%s (%#v)",
+					tt.obj, actual.Repr(), actual)
+			}
+		})
+	}
+}
+
 // checked by compiler (this function works nothing)
 func testArrIsPanObject() {
 	var _ PanObject = NewPanArr()

--- a/object/arr_test.go
+++ b/object/arr_test.go
@@ -112,6 +112,15 @@ func TestArrProto(t *testing.T) {
 	}
 }
 
+func TestInheritedArrProto(t *testing.T) {
+	arrChild := ChildPanObjPtr(NewPanArr(), EmptyPanObjPtr())
+	a := NewInheritedArr(arrChild)
+	if a.Proto() != arrChild {
+		t.Fatalf("Proto is not arrChild. got=%T (%s)",
+			a.Proto(), a.Proto().Inspect())
+	}
+}
+
 // checked by compiler (this function works nothing)
 func testArrIsPanObject() {
 	var _ PanObject = NewPanArr()
@@ -130,6 +139,37 @@ func TestNewPanArr(t *testing.T) {
 
 	for _, tt := range tests {
 		actual := NewPanArr(tt.elems...)
+
+		if len(actual.Elems) != len(tt.elems) {
+			t.Fatalf("wrong length. expected=%d, got=%d",
+				len(actual.Elems), len(tt.elems))
+		}
+
+		for i, e := range actual.Elems {
+			if e != tt.elems[i] {
+				t.Errorf("elems[%d] is wrong. expected=%s, got=%s",
+					i, tt.elems[i].Inspect(), e.Inspect())
+			}
+		}
+	}
+}
+
+func TestNewInheritedArr(t *testing.T) {
+	// child of Arr
+	proto := ChildPanObjPtr(NewPanArr(), EmptyPanObjPtr())
+
+	tests := []struct {
+		elems []PanObject
+	}{
+		{[]PanObject{}},
+		{[]PanObject{
+			NewPanInt(2),
+			NewPanStr("foo"),
+		}},
+	}
+
+	for _, tt := range tests {
+		actual := NewInheritedArr(proto, tt.elems...)
 
 		if len(actual.Elems) != len(tt.elems) {
 			t.Fatalf("wrong length. expected=%d, got=%d",

--- a/object/bool.go
+++ b/object/bool.go
@@ -35,6 +35,11 @@ func (b *PanBool) Proto() PanObject {
 	return BuiltInZeroInt
 }
 
+// Zero returns zero value of this object.
+func (b *PanBool) Zero() PanObject {
+	return b
+}
+
 // Hash returns hashkey of this object.
 func (b *PanBool) Hash() HashKey {
 	var v uint64

--- a/object/bool_test.go
+++ b/object/bool_test.go
@@ -64,6 +64,29 @@ func TestBoolProto(t *testing.T) {
 
 }
 
+func TestBoolZero(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *PanBool
+	}{
+		{"true", BuiltInTrue},
+		{"false", BuiltInFalse},
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.obj.Zero()
+
+			if actual != tt.obj {
+				t.Errorf("zero must be itself (%#v). got=%s (%#v)",
+					tt.obj, actual.Repr(), actual)
+			}
+		})
+	}
+}
+
 func TestBoolHash(t *testing.T) {
 	tests := []struct {
 		obj      PanBool

--- a/object/builtinfunc.go
+++ b/object/builtinfunc.go
@@ -31,6 +31,11 @@ func (b *PanBuiltIn) Proto() PanObject {
 	return BuiltInFuncObj
 }
 
+// Zero returns zero value of this object.
+func (b *PanBuiltIn) Zero() PanObject {
+	return b
+}
+
 // NewPanBuiltInFunc returns new BuiltInFunc object.
 func NewPanBuiltInFunc(f BuiltInFunc) *PanBuiltIn {
 	return &PanBuiltIn{f}

--- a/object/builtinfunc_test.go
+++ b/object/builtinfunc_test.go
@@ -42,6 +42,30 @@ func TestBuiltInProto(t *testing.T) {
 	}
 }
 
+func TestBuiltInZero(t *testing.T) {
+	f := func(e *Env, Kwargs *PanObj, args ...PanObject) PanObject { return args[0] }
+
+	tests := []struct {
+		name string
+		obj  *PanBuiltIn
+	}{
+		{"f", NewPanBuiltInFunc(f)},
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.obj.Zero()
+
+			if actual != tt.obj {
+				t.Errorf("zero must be itself (%#v). got=%s (%#v)",
+					tt.obj, actual.Repr(), actual)
+			}
+		})
+	}
+}
+
 // checked by compiler (this function works nothing)
 func testBuiltInIsPanObject() {
 	f := func(e *Env, Kwargs *PanObj, args ...PanObject) PanObject { return args[0] }

--- a/object/builtiniter.go
+++ b/object/builtiniter.go
@@ -30,6 +30,12 @@ func (b *PanBuiltInIter) Proto() PanObject {
 	return BuiltInIterObj
 }
 
+// Zero returns zero value of this object.
+func (b *PanBuiltInIter) Zero() PanObject {
+	// TODO: implement zero value
+	return b
+}
+
 // NewPanBuiltInIter returns new BuiltInIter object.
 func NewPanBuiltInIter(f BuiltInFunc, env *Env) *PanBuiltInIter {
 	return &PanBuiltInIter{f, env}

--- a/object/builtinobj.go
+++ b/object/builtinobj.go
@@ -5,25 +5,25 @@ package object
 // package object and package BuiltIn circular reference
 
 // BuiltInIntObj is an object of Int (proto of each int).
-var BuiltInIntObj = NewPanObj(&map[SymHash]Pair{}, BuiltInNumObj)
+var BuiltInIntObj = NewPanObj(&map[SymHash]Pair{}, BuiltInNumObj, WithZero(BuiltInZeroInt))
 
 // BuiltInFloatObj is an object of Float (proto of each float).
-var BuiltInFloatObj = NewPanObj(&map[SymHash]Pair{}, BuiltInNumObj)
+var BuiltInFloatObj = NewPanObj(&map[SymHash]Pair{}, BuiltInNumObj, WithZero(zeroFloat))
 
 // BuiltInNumObj is an object of Num.
 var BuiltInNumObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
 
 // BuiltInNilObj is an object of Nil (proto of nil).
-var BuiltInNilObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInNilObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj, WithZero(BuiltInNil))
 
 // BuiltInStrObj is an object of Str (proto of each str).
-var BuiltInStrObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInStrObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj, WithZero(zeroStr))
 
 // BuiltInArrObj is an object of Arr (proto of each arr).
-var BuiltInArrObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInArrObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj, WithZero(zeroArr))
 
 // BuiltInRangeObj is an object of Range (proto of each range).
-var BuiltInRangeObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInRangeObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj, WithZero(zeroRange))
 
 // BuiltInFuncObj is an object of Func (proto of each func).
 var BuiltInFuncObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
@@ -41,7 +41,7 @@ var BuiltInObjObj = NewPanObj(&map[SymHash]Pair{}, BuiltInBaseObj)
 var BuiltInBaseObj = NewPanObj(&map[SymHash]Pair{}, nil)
 
 // BuiltInMapObj is an object of Map (proto of each map).
-var BuiltInMapObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)
+var BuiltInMapObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj, WithZero(zeroMap))
 
 // BuiltInIOObj is an object of IO (proto of each io).
 var BuiltInIOObj = NewPanObj(&map[SymHash]Pair{}, BuiltInObjObj)

--- a/object/builtinobj_test.go
+++ b/object/builtinobj_test.go
@@ -1,0 +1,49 @@
+package object
+
+import "testing"
+
+// test zero values of *PanObj type BuiltInObj
+func TestBuiltInObjZeroValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      PanObject
+		expected PanObject
+	}{
+		{"BuiltInIntObj", BuiltInIntObj, BuiltInZeroInt},
+		{"BuiltInFloatObj", BuiltInFloatObj, zeroFloat},
+		{"BuiltInNumObj", BuiltInNumObj, zeroObj},
+		{"BuiltInNilObj", BuiltInNilObj, BuiltInNil},
+		{"BuiltInStrObj", BuiltInStrObj, zeroStr},
+		{"BuiltInArrObj", BuiltInArrObj, zeroArr},
+		{"BuiltInRangeObj", BuiltInRangeObj, zeroRange},
+		// {"", BuiltInFuncObj, zeroFunc},
+		// {"", BuiltInIterObj, zeroIter},
+		{"BuiltInIterableObj", BuiltInIterableObj, zeroObj},
+		{"BuiltInComparableObj", BuiltInComparableObj, zeroObj},
+		{"BuiltInWrappableObj", BuiltInWrappableObj, zeroObj},
+		// {"", BuiltInMatchObj, zeroMatch},
+		{"BuiltInObjObj", BuiltInObjObj, zeroObj},
+		{"BuiltInBaseObj", BuiltInBaseObj, zeroObj},
+		{"BuiltInMapObj", BuiltInMapObj, zeroMap},
+		{"BuiltInDiamondObj", BuiltInDiamondObj, zeroObj},
+		{"BuiltInKernelObj", BuiltInKernelObj, zeroObj},
+		{"BuiltInJSONObj", BuiltInJSONObj, zeroObj},
+		// {"", BuiltInEitherObj, zeroEither},
+		// {"", BuiltInEitherValObj, zeroEitherVal},
+		// {"", BuiltInEitherErrObj, zeroEitherErr},
+		// {"", BuiltInErrObj, zeroErr},
+		// (other errors...),
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.obj.Zero()
+			if actual != tt.expected {
+				t.Errorf("wrong zero value: expected %s, got %s",
+					tt.expected.Repr(), actual.Repr())
+			}
+		})
+	}
+}

--- a/object/deferobj.go
+++ b/object/deferobj.go
@@ -32,3 +32,9 @@ func (o *DeferObj) Proto() PanObject {
 	// never called
 	panic("deferObj does not have proto")
 }
+
+// Zero returns zero value of this object.
+func (e *DeferObj) Zero() PanObject {
+	// never called
+	panic("deferObj does not have zero")
+}

--- a/object/err.go
+++ b/object/err.go
@@ -35,6 +35,12 @@ func (e *PanErr) Proto() PanObject {
 	return e.proto
 }
 
+// Zero returns zero value of this object.
+func (e *PanErr) Zero() PanObject {
+	// TODO: implement zero value
+	return e
+}
+
 // Message returns error message.
 func (e *PanErr) Message() string {
 	return e.Msg

--- a/object/float.go
+++ b/object/float.go
@@ -8,9 +8,6 @@ import (
 // FloatType is a type of PanFloat.
 const FloatType = "FloatType"
 
-// used as zero value
-var zeroFloat = NewPanFloat(0.0)
-
 // PanFloat is object of float literal.
 type PanFloat struct {
 	Value float64
@@ -34,6 +31,11 @@ func (f *PanFloat) Repr() string {
 // Proto returns proto of this object.
 func (f *PanFloat) Proto() PanObject {
 	return BuiltInFloatObj
+}
+
+// Zero returns zero value of this object.
+func (f *PanFloat) Zero() PanObject {
+	return f
 }
 
 // Hash returns hashkey of this object.

--- a/object/float_test.go
+++ b/object/float_test.go
@@ -58,6 +58,28 @@ func TestFloatProto(t *testing.T) {
 	}
 }
 
+func TestFloatZero(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *PanFloat
+	}{
+		{"1.0", NewPanFloat(1.0)},
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.obj.Zero()
+
+			if actual != tt.obj {
+				t.Errorf("zero must be itself (%#v). got=%s (%#v)",
+					tt.obj, actual.Repr(), actual)
+			}
+		})
+	}
+}
+
 func TestFloatHash(t *testing.T) {
 	tests := []struct {
 		obj      *PanFloat

--- a/object/func.go
+++ b/object/func.go
@@ -45,6 +45,12 @@ func (f *PanFunc) Proto() PanObject {
 	return BuiltInFuncObj
 }
 
+// Zero returns zero value of this object.
+func (f *PanFunc) Zero() PanObject {
+	// TODO: implement zero value
+	return f
+}
+
 // FuncKind is a type of func-like objects.
 // NOTE: The type is used to designate func and iter because their implementation is
 // same type.

--- a/object/int.go
+++ b/object/int.go
@@ -32,6 +32,11 @@ func (i *PanInt) Proto() PanObject {
 	return BuiltInIntObj
 }
 
+// Zero returns zero value of this object.
+func (i *PanInt) Zero() PanObject {
+	return i
+}
+
 // Hash returns hashkey of this object.
 func (i *PanInt) Hash() HashKey {
 	return HashKey{IntType, uint64(i.Value)}

--- a/object/int_test.go
+++ b/object/int_test.go
@@ -57,6 +57,28 @@ func TestIntProto(t *testing.T) {
 	}
 }
 
+func TestIntZero(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *PanInt
+	}{
+		{"2", NewPanInt(2)},
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.obj.Zero()
+
+			if actual != tt.obj {
+				t.Errorf("zero must be itself (%#v). got=%s (%#v)",
+					tt.obj, actual.Repr(), actual)
+			}
+		})
+	}
+}
+
 func TestIntHash(t *testing.T) {
 	tests := []struct {
 		obj      *PanInt

--- a/object/io.go
+++ b/object/io.go
@@ -44,6 +44,12 @@ func (io *PanIO) Proto() PanObject {
 	return BuiltInIOObj
 }
 
+// Zero returns zero value of this object.
+func (io *PanIO) Zero() PanObject {
+	// TODO: implement zero value
+	return io
+}
+
 // ReadLine reads line from in and returns it as PanStr.
 func (io *PanIO) ReadLine() (*PanStr, bool) {
 	if !io.scanner.Scan() {

--- a/object/map.go
+++ b/object/map.go
@@ -8,9 +8,6 @@ import (
 // MapType is a type of PanMap.
 const MapType = "MapType"
 
-// used as zero value
-var zeroMap = NewEmptyPanMap()
-
 // PanMap is object of map literal.
 type PanMap struct {
 	// used to keep map order
@@ -85,6 +82,11 @@ func (m *PanMap) Repr() string {
 // Proto returns proto of this object.
 func (m *PanMap) Proto() PanObject {
 	return BuiltInMapObj
+}
+
+// Zero returns zero value of this object.
+func (m *PanMap) Zero() PanObject {
+	return m
 }
 
 // NewPanMap returns new map object.

--- a/object/map_test.go
+++ b/object/map_test.go
@@ -235,6 +235,28 @@ func TestMapProto(t *testing.T) {
 	}
 }
 
+func TestMapZero(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *PanMap
+	}{
+		{"%{'a: 1}", NewPanMap(Pair{NewPanStr("a"), NewPanInt(1)})},
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.obj.Zero()
+
+			if actual != tt.obj {
+				t.Errorf("zero must be itself (%#v). got=%s (%#v)",
+					tt.obj, actual.Repr(), actual)
+			}
+		})
+	}
+}
+
 // checked by compiler (this function works nothing)
 func testMapIsPanObject() {
 	var _ PanObject = NewEmptyPanMap()

--- a/object/match.go
+++ b/object/match.go
@@ -29,6 +29,12 @@ func (m *PanMatch) Proto() PanObject {
 	return BuiltInMatchObj
 }
 
+// Zero returns zero value of this object.
+func (m *PanMatch) Zero() PanObject {
+	// TODO: implement zero value
+	return m
+}
+
 // MatchWrapper is a wrapper for match literal ast node.
 // NOTE: keep loose coupling to ast.MatchLiteral and PanMatch
 // ast.MatchLiteral implements MatchWrapper

--- a/object/nil.go
+++ b/object/nil.go
@@ -26,6 +26,11 @@ func (n *PanNil) Proto() PanObject {
 	return BuiltInNilObj
 }
 
+// Zero returns zero value of this object.
+func (n *PanNil) Zero() PanObject {
+	return BuiltInNil
+}
+
 // Hash returns hashkey of this object.
 func (n *PanNil) Hash() HashKey {
 	return HashKey{NilType, 0}

--- a/object/nil_test.go
+++ b/object/nil_test.go
@@ -51,6 +51,28 @@ func TestNilProto(t *testing.T) {
 	}
 }
 
+func TestNilZero(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *PanNil
+		expected PanObject
+	}{
+		{"nil", NewPanNil(), BuiltInNil},
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.obj.Zero()
+			if actual != tt.expected {
+				t.Errorf("zero value must be %s. got=%s",
+					tt.expected.Repr(), actual.Repr())
+			}
+		})
+	}
+}
+
 func TestNilHash(t *testing.T) {
 	tests := []struct {
 		obj      *PanNil

--- a/object/obj_test.go
+++ b/object/obj_test.go
@@ -405,6 +405,47 @@ func TestObjPrivateKeys(t *testing.T) {
 	}
 }
 
+func TestObjZeroValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *PanObj
+		expected PanObject
+	}{
+		{
+			"BaseObj has zero value {}",
+			BuiltInBaseObj,
+			zeroObj,
+		},
+		{
+			"Obj has zero value {}",
+			BuiltInObjObj,
+			zeroObj,
+		},
+		{
+			"inherit from proto",
+			ChildPanObjPtr(BuiltInArrObj, EmptyPanObjPtr()),
+			zeroArr,
+		},
+		{
+			"set zero value explicitly",
+			ChildPanObjPtr(EmptyPanObjPtr(), EmptyPanObjPtr(), WithZero(zeroArr)),
+			zeroArr,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.obj.Zero()
+			if actual != tt.expected {
+				t.Errorf("zero value must be %s. got=%s",
+					tt.expected.Repr(), actual.Repr())
+			}
+		})
+	}
+}
+
 func TestEmptyPanObjPtr(t *testing.T) {
 	actual := EmptyPanObjPtr()
 
@@ -454,6 +495,10 @@ func TestChildPanObjPtr(t *testing.T) {
 
 		if actual.Proto() != tt.proto {
 			t.Errorf("Proto must be tt.proto. got=%s", actual.Proto().Inspect())
+		}
+
+		if actual.Zero() != tt.proto.Zero() {
+			t.Errorf("Zero must be %s. got=%s", tt.proto.Zero(), actual.Proto().Inspect())
 		}
 
 		if actual.Pairs != tt.src.Pairs {

--- a/object/object.go
+++ b/object/object.go
@@ -14,6 +14,7 @@ type PanObject interface {
 	Inspect() string
 	Repr() string
 	Proto() PanObject
+	Zero() PanObject
 }
 
 // PanScalar is an interface of scalar PanObject, which does not have child components.

--- a/object/range.go
+++ b/object/range.go
@@ -8,9 +8,6 @@ import (
 // RangeType is a type of PanRange.
 const RangeType = "RangeType"
 
-// used as zero value
-var zeroRange = NewPanRange(BuiltInNil, BuiltInNil, BuiltInNil)
-
 // PanRange is object of range literal.
 type PanRange struct {
 	Start PanObject
@@ -54,6 +51,11 @@ func (r *PanRange) Repr() string {
 // Proto returns proto of this object.
 func (r *PanRange) Proto() PanObject {
 	return BuiltInRangeObj
+}
+
+// Zero returns zero value of this object.
+func (r *PanRange) Zero() PanObject {
+	return r
 }
 
 // NewPanRange returns new range object.

--- a/object/range_test.go
+++ b/object/range_test.go
@@ -112,6 +112,28 @@ func TestRangeProto(t *testing.T) {
 	}
 }
 
+func TestRangeZero(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *PanRange
+	}{
+		{"(1:2:3)", NewPanRange(NewPanInt(1), NewPanInt(2), NewPanInt(3))},
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.obj.Zero()
+
+			if actual != tt.obj {
+				t.Errorf("zero must be itself (%#v). got=%s (%#v)",
+					tt.obj, actual.Repr(), actual)
+			}
+		})
+	}
+}
+
 // checked by compiler (this function works nothing)
 func testRangeIsPanObject() {
 	var _ PanObject = NewPanRange(NewPanInt(1), NewPanInt(2), NewPanInt(3))

--- a/object/str.go
+++ b/object/str.go
@@ -9,9 +9,6 @@ import (
 // StrType is a type of PanStr.
 const StrType = "StrType"
 
-// used as zero value
-var zeroStr = NewPanStr("")
-
 // PanStr is object of str literal.
 type PanStr struct {
 	Value    string
@@ -42,6 +39,11 @@ func (s *PanStr) Repr() string {
 // Proto returns proto of this object.
 func (s *PanStr) Proto() PanObject {
 	return BuiltInStrObj
+}
+
+// Zero returns zero value of this object.
+func (s *PanStr) Zero() PanObject {
+	return s
 }
 
 // Hash returns hashkey of this object.

--- a/object/str_test.go
+++ b/object/str_test.go
@@ -61,6 +61,28 @@ func TestStrProto(t *testing.T) {
 	}
 }
 
+func TestStrZero(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *PanStr
+	}{
+		{`"a"`, NewPanStr("a")},
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin
+
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.obj.Zero()
+
+			if actual != tt.obj {
+				t.Errorf("zero must be itself (%#v). got=%s (%#v)",
+					tt.obj, actual.Repr(), actual)
+			}
+		})
+	}
+}
+
 func TestStrHash(t *testing.T) {
 	tests := []struct {
 		obj      *PanStr

--- a/object/traceproto.go
+++ b/object/traceproto.go
@@ -3,13 +3,14 @@ package object
 // TraceProtoOfArr traces proto chain of obj and returns arr proto.
 func TraceProtoOfArr(obj PanObject) (*PanArr, bool) {
 	for o := obj; o.Proto() != nil; o = o.Proto() {
-		// HACK: proto of Arr is zero value [] so that Arr itself can be used as arr object
-		if o == BuiltInArrObj {
-			return zeroArr, true
-		}
-
 		if v, ok := o.(*PanArr); ok {
 			return v, true
+		}
+
+		// HACK: Arr is treated as zero value [] so that Arr itself can be used as arr object
+		// (Arr's descendants are treated as empty arr as well)
+		if a, ok := o.Zero().(*PanArr); ok {
+			return a, true
 		}
 	}
 	return nil, false

--- a/object/traceproto_test.go
+++ b/object/traceproto_test.go
@@ -5,45 +5,43 @@ import (
 )
 
 func TestTraceProtoOfArr(t *testing.T) {
-	proto := NewPanArr()
-
 	tests := []struct {
+		name     string
 		obj      PanObject
 		expected *PanArr
 	}{
-		// return proto
 		{
-			NewPanObj(&map[SymHash]Pair{}, proto),
-			proto,
+			"arr returns itself",
+			zeroArr,
+			zeroArr,
 		},
-		// return itself
 		{
-			proto,
-			proto,
-		},
-		// Arr returns zero value [] so that Arr itself can be used as arr object
-		{
+			"Arr returns zero value [] so that Arr itself can be used as arr object",
 			BuiltInArrObj,
 			zeroArr,
 		},
-		// child of Arr
 		{
+			"child of Arr returns zero value []",
 			NewPanObj(&map[SymHash]Pair{}, BuiltInArrObj),
 			zeroArr,
 		},
 	}
 
 	for _, tt := range tests {
-		actual, ok := TraceProtoOfArr(tt.obj)
+		tt := tt // pin
 
-		if !ok {
-			t.Errorf("ok must be true (obj=%v)", tt.obj)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			actual, ok := TraceProtoOfArr(tt.obj)
 
-		if actual != tt.expected {
-			t.Errorf("proto must be %+v(%T). got=%+v(%T)",
-				tt.expected, tt.expected, actual, actual)
-		}
+			if !ok {
+				t.Fatalf("ok must be true (obj=%s)", tt.obj.Repr())
+			}
+
+			if actual != tt.expected {
+				t.Errorf("proto must be %s(%T). got=%s(%T)",
+					tt.expected.Repr(), tt.expected, actual.Repr(), actual)
+			}
+		})
 	}
 }
 

--- a/object/zerovalue.go
+++ b/object/zerovalue.go
@@ -1,0 +1,30 @@
+package object
+
+// NOTE: zero value should be initialized in init() (evaluated after vars),
+// otherwise initialization cycle occurs
+// i.e.) zeroArr.proto requires BuiltInArrObj and BuiltInArrObj.zero requires zeroArr
+func init() {
+	// set protos
+	zeroArr.proto = BuiltInArrObj
+
+	// set zero values
+	zeroObj.zero = zeroObj
+}
+
+// used as zero value
+var zeroArr = &PanArr{}
+var zeroFloat = NewPanFloat(0.0)
+var zeroMap = NewEmptyPanMap()
+
+// NOTE: EmptyPanObjPtr cannot be used, otherwise initialization cycle occurs
+var zeroObj = &PanObj{
+	Pairs:       &map[SymHash]Pair{},
+	Keys:        &[]SymHash{},
+	PrivateKeys: &[]SymHash{},
+	proto:       BuiltInBaseObj,
+	// zero value cannot be set here
+	// zero: zeroObj,
+}
+
+var zeroRange = NewPanRange(BuiltInNil, BuiltInNil, BuiltInNil)
+var zeroStr = NewPanStr("")

--- a/props/arr_props.go
+++ b/props/arr_props.go
@@ -129,6 +129,39 @@ func ArrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 				return object.BuiltInTrue
 			},
 		),
+		// NOTE: override bear to set arr zero values
+		"bear": f(
+			func(
+				env *object.Env, kwargs *object.PanObj, args ...object.PanObject,
+			) object.PanObject {
+				if len(args) < 1 {
+					return object.NewTypeErr("Arr#bear requires at least 1 arg")
+				}
+				proto := args[0]
+
+				// if soruce is not specified as arg, use {}
+				src := object.EmptyPanObjPtr()
+				if len(args) >= 2 {
+					// `proto.bear(arg)`
+					arg, ok := args[1].(*object.PanObj)
+					if !ok {
+						return object.NewTypeErr("Arr#bear requires obj literal src")
+					}
+					src = arg
+				}
+
+				// if self is concrete value, use it as zero value
+				if proto.Type() == object.ArrType {
+					return object.ChildPanObjPtr(proto, src, object.WithZero(proto))
+				}
+
+				// otherwise zero value is an empty arr inherited from the generated obj
+				return object.ChildPanObjPtr(proto, src,
+					object.WithZeroFromSelf(func(o *object.PanObj) object.PanObject {
+						return object.NewInheritedArr(o)
+					}))
+			},
+		),
 		"call": f(
 			func(
 				env *object.Env, kwargs *object.PanObj, args ...object.PanObject,
@@ -270,7 +303,8 @@ func ArrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 						fmt.Sprintf("%s cannot be treated as arr", args[1].Repr()))
 				}
 
-				return arr
+				// NOTE: Arr's descendants also call this
+				return object.NewInheritedArr(args[0], arr.Elems...)
 			},
 		),
 		"O": f(

--- a/props/arr_props.go
+++ b/props/arr_props.go
@@ -137,7 +137,8 @@ func ArrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 					return object.NewTypeErr("Arr#call requires at least 1 arg")
 				}
 
-				return object.NewPanArr(args[1:]...)
+				// NOTE: Arr's descendants also call this
+				return object.NewInheritedArr(args[0], args[1:]...)
 			},
 		),
 		"has?": f(
@@ -324,6 +325,10 @@ func compArrs(
 	env *object.Env,
 ) object.PanObject {
 	if len(a1.Elems) != len(a2.Elems) {
+		return object.BuiltInFalse
+	}
+
+	if a1.Proto() != a2.Proto() {
 		return object.BuiltInFalse
 	}
 

--- a/tests/Arr_call_test.pangaea
+++ b/tests/Arr_call_test.pangaea
@@ -1,0 +1,4 @@
+# child of Arr can bear its child (not Arr's child)
+ChildArr := Arr.bear
+assertEq(ChildArr(1, 2, 3).proto, ChildArr)
+assertEq(ChildArr(1, 2, 3).A, [1, 2, 3])

--- a/tests/Arr_new_test.pangaea
+++ b/tests/Arr_new_test.pangaea
@@ -1,0 +1,4 @@
+# child of Arr can bear its child (not Arr's child)
+ChildArr := Arr.bear
+assertEq(ChildArr.new([1, 2, 3]).proto, ChildArr)
+assertEq(ChildArr.new([1, 2, 3]).A, [1, 2, 3])

--- a/tests/Obj_bro_test.pangaea
+++ b/tests/Obj_bro_test.pangaea
@@ -1,3 +1,2 @@
 assertEq({a: 1}.bro({b: 2}), {b: 2})
-assertEq([1, 2].bro({a: 1}), Arr.bear({a: 1}))
-assertEq(true.bro({a: 1}), 1.bear({a: 1}))
+assertEq({a: 1}.bear({b: 2}).bro({c: 3}), {a: 1}.bear({c: 3}))


### PR DESCRIPTION
Arr's descendants can create its own child.

```
# before
>>> Child := Arr.bear({_name: 'Child, hoge: m{'hoge.p}})
Child
>>> Child(1,2,3).hoge
NoPropErr: property `hoge` is not defined.
>>> Child(1,2,3).proto
Arr
```

```
# after
>>> Child := Arr.bear({_name: 'Child, hoge: m{'hoge.p}})
Child
>>> Child(1,2,3).hoge
hoge
nil
>>> Child(1,2,3).proto
Child
```

Also, descendant's zero value inherits the descendant so that it can use any own methods.