### PR TITLE
props: fix Arr#O not to overwrite duplicated keys

### DIFF
--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -5167,6 +5167,13 @@ func TestEvalObjectify(t *testing.T) {
 				{Key: object.NewPanStr("b"), Value: object.NewPanStr("2")},
 			}),
 		},
+		// if keys are duplicated, first value is set
+		{
+			`[['a, 1], ['a, 2]].O`,
+			toPanObj([]object.Pair{
+				{Key: object.NewPanStr("a"), Value: object.NewPanInt(1)},
+			}),
+		},
 	}
 
 	for _, tt := range tests {
@@ -5202,6 +5209,16 @@ func TestEvalArrM(t *testing.T) {
 				[]object.Pair{
 					{Key: object.NewPanStr("hi"), Value: object.NewPanInt(1)},
 					{Key: object.NewPanInt(4), Value: object.NewPanStr("2")},
+				},
+				[]object.Pair{},
+			),
+		},
+		// if keys are duplicated, first value is set
+		{
+			`[['a, 1], ['a, 2]].M`,
+			toPanMap(
+				[]object.Pair{
+					{Key: object.NewPanStr("a"), Value: object.NewPanInt(1)},
 				},
 				[]object.Pair{},
 			),

--- a/props/arr_props.go
+++ b/props/arr_props.go
@@ -340,9 +340,11 @@ func ArrProps(propContainer map[string]object.PanObject) map[string]object.PanOb
 							fmt.Sprintf(`element key %s cannot be treated as str`, arr.Elems[0].Repr()))
 					}
 
-					pairs[object.GetSymHash(k.Value)] = object.Pair{
-						Key:   k,
-						Value: arr.Elems[1],
+					if _, exists := pairs[object.GetSymHash(k.Value)]; !exists {
+						pairs[object.GetSymHash(k.Value)] = object.Pair{
+							Key:   k,
+							Value: arr.Elems[1],
+						}
 					}
 				}
 


### PR DESCRIPTION
```
# before
>>> {a: 1, a: 2}
{"a": 1}
>>> [['a, 1], ['a, 2]].O
{"a": 2}

# after
>>>  {a: 1, a: 2}
{"a": 1}
>>>  [['a, 1], ['a, 2]].O
{"a": 1}
```